### PR TITLE
Temporarily pointing to ARMmbed/mbed-os client-fixme branch

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a326c13f78038705d84b17a8e92b8a3b9b043709
+https://github.com/ARMmbed/mbed-os/#f6592621b87a97fdf3d42a15e447ccc58dd0c1e4


### PR DESCRIPTION
- fixes missing uvisor-lib-reference
