### PR TITLE
Update mbed-os.lib

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c55c09ab21d243279f2370fc0483cc479b9d1262
+https://github.com/ARMmbed/mbed-os/#8e35c53493956aee3b390b7a6c311c67545e4eff


### PR DESCRIPTION
This is required to use the EPR version of mbed. Verified it builds ok.

@sg- 
