### PR TITLE
Reverting mbed-os-5.2.1 to mbed-os-5.2.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#e435a07d9252f133ea3d9f6c95dfb176f32ab9b6


### PR DESCRIPTION
Need to revert back mbed-os version as the newer version caused regression with Mesh connectivity.