### PR TITLE
Switch the default transport-mode to TCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,12 +238,12 @@ If your network does not have DHCP enabled, you have to manually assign a static
 
 ### Changing socket type
 
-Your device can connect to mbed Device Connector via UDP or TCP binding mode. The default is UDP. The binding mode cannot be changed in 6LoWPAN ND or Thread mode.
+Your device can connect to mbed Device Connector via UDP or TCP binding mode. The default is TCP. The binding mode cannot be changed in 6LoWPAN ND or Thread mode.
 
 To change the binding mode:
 
-1. In the `simpleclient.h` file, find the parameter `SOCKET_MODE`. The default is `M2MInterface::UDP`.
-1. To switch to TCP, change it to `M2MInterface::TCP`.
+1. In the `simpleclient.h` file, find the parameter `SOCKET_MODE`. The default is `M2MInterface::TCP`.
+1. To switch to UDP, change it to `M2MInterface::UDP`.
 1. Rebuild and flash the application.
 
 <span class="tips">**Tip:** The instructions in this document remain the same, irrespective of the socket mode you select.</span>

--- a/simpleclient.h
+++ b/simpleclient.h
@@ -42,7 +42,7 @@
 M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv4;
 
 //Select binding mode: UDP or TCP
-M2MInterface::BindingMode SOCKET_MODE = M2MInterface::UDP;
+M2MInterface::BindingMode SOCKET_MODE = M2MInterface::TCP;
 
 
 // MBED_DOMAIN and MBED_ENDPOINT_NAME come


### PR DESCRIPTION
The UDP tends to be quite unreliable with IPv4 and NAT and this
can give bad experience for new users. We should default to TCP
to provide more stable platform for testing the capabilities.