### PR TITLE
mbedOS 5.3 RC2

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f
+https://github.com/ARMmbed/mbed-os/#503262c91bc51619ec540490d3e4a058e0c8ebf1


### PR DESCRIPTION
Release candidate number 2 hash for mbed-os.lib.