### PR TITLE
Change socket mode to UDP for mesh in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,6 +88,11 @@ def buildStep(target, compilerLabel, toolchain, configName, connectiontype) {
             execute ("sed -i 's/\"mbed-mesh-api.6lowpan-nd-channel\": 12/\"mbed-mesh-api.6lowpan-nd-channel\": 18/' mbed_app.json")
           }
 
+          if ("${configName}" == "6lp" || "${configName}" == "thd") {
+            // Change socket mode to UDP
+            execute ("sed -i 's/M2MInterface::BindingMode SOCKET_MODE = M2MInterface::TCP/M2MInterface::BindingMode SOCKET_MODE = M2MInterface::UDP/' simpleclient.h")
+          }
+
           if ("${connectiontype}" == "MCR20") {
             // Replace default rf shield
             execute ("sed -i 's/\"value\": \"ATMEL\"/\"value\": \"MCR20\"/' mbed_app.json")


### PR DESCRIPTION
Change socket mode to UDP for mesh in Jenkinsfile

* Change binding mode to UDP in simpleclient.h if building for mesh
This is a workaround for IOTCLT-1296

@teetak01 @SeppoTakalo 
CC @jankii01 @artokin 