### PR TITLE
better support IPv6/Mesh networking/UBLOX EVK_ODIN_W2

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -37,6 +37,7 @@ EthernetInterface eth;
 LoWPANNDInterface mesh;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
 #define MESH
+#define IPV6
 #include "NanostackInterface.h"
 ThreadInterface mesh;
 #endif
@@ -52,11 +53,12 @@ NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, M
 #endif //MBED_CONF_APP_RADIO_TYPE
 #endif //MESH
 
-#ifndef MESH
-// This is address to mbed Device Connector
+#if not defined (MESH) || (MBED_CONF_LWIP_IPV4_ENABLED) || (MBED_CONF_LWIP_IP_VER_PREF == 4)
+// This is IPv4 address to mbed Device Connector
 #define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
 #else
-// This is address to mbed Device Connector
+// This is IPv6 address to mbed Device Connector
+// mesh is always IPv6
 #define MBED_SERVER_ADDRESS "coaps://[2607:f0d0:2601:52::20]:5684"
 #endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -57,13 +57,21 @@ NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, M
 #endif //MBED_CONF_APP_RADIO_TYPE
 #endif //MESH
 
-#if not defined (MESH) || (MBED_CONF_LWIP_IPV4_ENABLED) || (MBED_CONF_LWIP_IP_VER_PREF == 4)
-// This is IPv4 address to mbed Device Connector
-#define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
+#if defined MESH
+#define IPV6
+#elif MBED_CONF_LWIP_IPV6_ENABLED==true
+#define IPV6
 #else
-// This is IPv6 address to mbed Device Connector
-// mesh is always IPv6
-#define MBED_SERVER_ADDRESS "coaps://[2607:f0d0:2601:52::20]:5684"
+#define IPV4
+#endif
+
+#ifdef IPV6
+    // This is IPv6 address to mbed Device Connector
+    // mesh is always IPv6
+    #define MBED_SERVER_ADDRESS "coaps://[2607:f0d0:2601:52::20]:5684"
+#else
+    // This is IPv4 address to mbed Device Connector
+    #define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
 #endif
 
 RawSerial output(USBTX, USBRX);
@@ -391,7 +399,6 @@ Add MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES and MBEDTLS_TEST_NULL_ENTROPY in mbed_app
     NetworkInterface *network_interface = 0;
     int connect_success = -1;
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI
-    output.printf("\n\rUsing WiFi \r\n");
     output.printf("\n\rConnecting to WiFi..\r\n");
     connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD);
     network_interface = &wifi;
@@ -419,7 +426,6 @@ Add MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES and MBEDTLS_TEST_NULL_ENTROPY in mbed_app
     } else {
         output.printf("No IP address\r\n");
     }
-
     // we create our button and LED resources
     ButtonResource button_resource;
     LedResource led_resource;

--- a/main.cpp
+++ b/main.cpp
@@ -26,20 +26,24 @@
 #include "rtos.h"
 
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI
-#include "ESP8266Interface.h"
-ESP8266Interface esp(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+    #if TARGET_UBLOX_EVK_ODIN_W2
+        #include "OdinWiFiInterface.h"
+        OdinWiFiInterface wifi;
+	#else
+		#include "ESP8266Interface.h"
+		ESP8266Interface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+    #endif
 #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
-#include "EthernetInterface.h"
-EthernetInterface eth;
+    #include "EthernetInterface.h"
+    EthernetInterface eth;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
-#define MESH
-#include "NanostackInterface.h"
-LoWPANNDInterface mesh;
+    #define MESH
+    #include "NanostackInterface.h"
+    LoWPANNDInterface mesh;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
-#define MESH
-#define IPV6
-#include "NanostackInterface.h"
-ThreadInterface mesh;
+    #define MESH
+    #include "NanostackInterface.h"
+    ThreadInterface mesh;
 #endif
 
 #if defined(MESH)
@@ -389,8 +393,8 @@ Add MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES and MBEDTLS_TEST_NULL_ENTROPY in mbed_app
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI
     output.printf("\n\rUsing WiFi \r\n");
     output.printf("\n\rConnecting to WiFi..\r\n");
-    connect_success = esp.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD);
-    network_interface = &esp;
+    connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD);
+    network_interface = &wifi;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
     output.printf("Using Ethernet\r\n");
     connect_success = eth.connect();

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -28,7 +28,8 @@
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
     "target_overrides": {
         "*": {
-            "target.features_add": ["NANOSTACK", "LOWPAN_ROUTER", "COMMON_PAL"],
+            "target.features_add": ["LWIP", "NANOSTACK", "LOWPAN_ROUTER", "COMMON_PAL"],
+            "lwip.ipv4-enabled":1, "lwip.ipv6-enabled":0,
             "mbed-mesh-api.6lowpan-nd-channel-page": 0,
             "mbed-mesh-api.6lowpan-nd-channel": 12,
             "mbed-trace.enable": 0

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -29,7 +29,8 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["LWIP", "NANOSTACK", "LOWPAN_ROUTER", "COMMON_PAL"],
-            "lwip.ipv4-enabled":1, "lwip.ipv6-enabled":0,
+            "lwip.ipv4-enabled":false,
+            "lwip.ipv6-enabled":true,
             "mbed-mesh-api.6lowpan-nd-channel-page": 0,
             "mbed-mesh-api.6lowpan-nd-channel": 12,
             "mbed-trace.enable": 0

--- a/simpleclient.h
+++ b/simpleclient.h
@@ -38,12 +38,28 @@
 
 #define STRINGIFY(s) #s
 
-//Select network stack mode: IPv4 or IPv6
-M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv4;
 
-//Select binding mode: UDP or TCP
-M2MInterface::BindingMode SOCKET_MODE = M2MInterface::TCP;
+//Select binding mode: UDP or TCP -- note - Mesh networking is IPv6 UDP ONLY
+#if MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND || MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
+	M2MInterface::BindingMode SOCKET_MODE = M2MInterface::UDP;
+#else
+	// WiFi or Ethernet supports both - TCP by default to avoid
+	// NAT problems, but UDP will also work - IF you configure
+	// your network right.
+    M2MInterface::BindingMode SOCKET_MODE = M2MInterface::TCP;
+#endif
 
+#if defined(MBED_CONF_LWIP_IPV4_ENABLED) || (MBED_CONF_LWIP_IP_VER_PREF == 4)
+    M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv4;
+#else
+// In case of Mesh or Thread use M2MInterface::Nanostack_IPv6
+    #if (MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND) || 
+        (MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD)
+        M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::Nanostack_IPv6;
+    #else // ETH or WiFi
+        M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv6;
+    #endif
+#endif
 
 // MBED_DOMAIN and MBED_ENDPOINT_NAME come
 // from the security.h file copied from connector.mbed.com
@@ -106,13 +122,6 @@ public:
     // Randomizing listening port for Certificate mode connectivity
     _server_address = server_address;
     uint16_t port = rand() % 65535 + 12345;
-
-    // In case of Mesh or Thread use M2MInterface::Nanostack_IPv6
-#if MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
-    NETWORK_STACK = M2MInterface::Nanostack_IPv6;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
-    NETWORK_STACK = M2MInterface::Nanostack_IPv6;
-#endif
 
     // create mDS interface object, this is the base object everything else attaches to
     _interface = M2MInterfaceFactory::create_interface(*this,


### PR DESCRIPTION
Wrong server address was used sometimes. Default connection also now
to UDP in mesh networking vs. TCP in WiFi/ethernet.