### PR TITLE
Support for UBLOX_EVK_ODIN_W2 / Odin WiFi

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -26,19 +26,24 @@
 #include "rtos.h"
 
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI
-#include "ESP8266Interface.h"
-ESP8266Interface esp(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+    #if TARGET_UBLOX_EVK_ODIN_W2
+        #include "OdinWiFiInterface.h"
+        OdinWiFiInterface wifi;
+	#else
+		#include "ESP8266Interface.h"
+		ESP8266Interface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+    #endif
 #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
-#include "EthernetInterface.h"
-EthernetInterface eth;
+    #include "EthernetInterface.h"
+    EthernetInterface eth;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
-#define MESH
-#include "NanostackInterface.h"
-LoWPANNDInterface mesh;
+    #define MESH
+    #include "NanostackInterface.h"
+    LoWPANNDInterface mesh;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
-#define MESH
-#include "NanostackInterface.h"
-ThreadInterface mesh;
+    #define MESH
+    #include "NanostackInterface.h"
+    ThreadInterface mesh;
 #endif
 
 #if defined(MESH)
@@ -387,8 +392,8 @@ Add MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES and MBEDTLS_TEST_NULL_ENTROPY in mbed_app
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI
     output.printf("\n\rUsing WiFi \r\n");
     output.printf("\n\rConnecting to WiFi..\r\n");
-    connect_success = esp.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD);
-    network_interface = &esp;
+    connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD);
+    network_interface = &wifi;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
     output.printf("Using Ethernet\r\n");
     connect_success = eth.connect();


### PR DESCRIPTION
Support for UBLOX_EVK_ODIN_W2 WiFi module via an #ifdef -hack. Original
from:

https://github.com/ARMmbed/oob-mbed-os-example-client/pull/18/

NOTE! Requires mbedOS 5.3 with Odin wifi -fix, fails to link
otherwise.