### PR TITLE
Simplify UPD and IPv4/IPv6 selections

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -57,12 +57,13 @@ NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, M
 #endif //MBED_CONF_APP_RADIO_TYPE
 #endif //MESH
 
-#ifndef MESH
-// This is address to mbed Device Connector
-#define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
+#ifdef MESH
+    // Mesh does not have DNS, so must use direct IPV6 address
+    #define MBED_SERVER_ADDRESS "coaps://[2607:f0d0:2601:52::20]:5684"
 #else
-// This is address to mbed Device Connector
-#define MBED_SERVER_ADDRESS "coaps://[2607:f0d0:2601:52::20]:5684"
+    // This is address to mbed Device Connector, name based
+    // assume all other stacks support DNS properly
+    #define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
 #endif
 
 RawSerial output(USBTX, USBRX);

--- a/simpleclient.h
+++ b/simpleclient.h
@@ -38,11 +38,23 @@
 
 #define STRINGIFY(s) #s
 
-//Select network stack mode: IPv4 or IPv6
-M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv4;
+#if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
+    // Mesh is always IPV6 - also WiFi and ETH can be IPV6 if IPV6 is enabled
+    M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv6;
+#else
+    // Everything else - we assume it's IPv4
+    M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv4;
+#endif
 
-//Select binding mode: UDP or TCP
-M2MInterface::BindingMode SOCKET_MODE = M2MInterface::TCP;
+//Select binding mode: UDP or TCP -- note - Mesh networking is IPv6 UDP ONLY
+#ifdef MESH
+	M2MInterface::BindingMode SOCKET_MODE = M2MInterface::UDP;
+#else
+	// WiFi or Ethernet supports both - TCP by default to avoid
+	// NAT problems, but UDP will also work - IF you configure
+	// your network right.
+    M2MInterface::BindingMode SOCKET_MODE = M2MInterface::TCP;
+#endif
 
 
 // MBED_DOMAIN and MBED_ENDPOINT_NAME come
@@ -106,13 +118,6 @@ public:
     // Randomizing listening port for Certificate mode connectivity
     _server_address = server_address;
     uint16_t port = rand() % 65535 + 12345;
-
-    // In case of Mesh or Thread use M2MInterface::Nanostack_IPv6
-#if MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
-    NETWORK_STACK = M2MInterface::Nanostack_IPv6;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
-    NETWORK_STACK = M2MInterface::Nanostack_IPv6;
-#endif
 
     // create mDS interface object, this is the base object everything else attaches to
     _interface = M2MInterfaceFactory::create_interface(*this,


### PR DESCRIPTION
Idea is that MESH has to have hard-coded IPv6 server address, because
it does not have DNS capability. Other networks should have.

Also, UDP must be used with MESH - other networks we want to default to
TCP because it is typically more reliable (UDP gets closed due to firewalls).

Thirdly, IPv4/IPv6 selection should now happen automatically through
the mbed_app.json selections with no need to modify the .h-file anymore
by modifying the
            "lwip.ipv4-enabled": false,
            "lwip.ipv6-enabled": true
selections accordingly.