### PR TITLE
Nanostack eth support

### DIFF
--- a/configs/Nanostack_ETH_config.json
+++ b/configs/Nanostack_ETH_config.json
@@ -1,0 +1,16 @@
+{
+    "config": {
+       "network-interface":{
+            "help": "options are LWIP_ETHERNET,WIFI,MESH_LOWPAN_ND,MESH_THREAD, NANOSTACK_ETHERNET",
+            "value": "LWIP_ETHERNET"
+        }        
+    },
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
+    "target_overrides": {
+        "*": {
+            "target.features_add": ["NANOSTACK", "COMMON_PAL"],
+            "mbed-trace.enable": 1,
+            "nanostack.configuration": "ethernet_host"
+        }        
+    }
+}

--- a/configs/Thread_Atmel_RF_config.json
+++ b/configs/Thread_Atmel_RF_config.json
@@ -1,0 +1,30 @@
+{
+    "config": {
+        "network-interface":{
+            "help": "options are ETHERNET,WIFI,MESH_LOWPAN_ND,MESH_THREAD",
+            "value": "MESH_THREAD"
+        },
+        "mesh_radio_type": {
+        	"help": "options are ATMEL, MCR20",
+        	"value": "ATMEL"
+        }
+    },
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
+    "target_overrides": {
+        "*": {
+            "target.features_add": ["NANOSTACK", "THREAD_ROUTER", "COMMON_PAL"],
+            "mbed-mesh-api.thread-pskd": "\"abcdefghijklmno\"",
+            "mbed-mesh-api.thread-config-pskc": "{0xc8, 0xa6, 0x2e, 0xae, 0xf3, 0x68, 0xf3, 0x46, 0xa9, 0x9e, 0x57, 0x85, 0x98, 0x9d, 0x1c, 0xd0}",
+            "mbed-mesh-api.thread-config-channel-page": 0,
+            "mbed-mesh-api.thread-config-channel": 22,
+            "mbed-trace.enable": 1,
+            "mbed-mesh-api.thread-config-panid": "0x0700",
+            "mbed-mesh-api.thread-config-network-name": "\"Thread Network\"",
+            "mbed-mesh-api.thread-config-commissioning-dataset-timestamp": "0x00000001",
+            "mbed-mesh-api.thread-config-extended-panid": "{0xf1, 0xb5, 0xa1, 0xb2,0xc4, 0xd5, 0xa1, 0xbd }",
+            "mbed-mesh-api.thread-master-key": "{0x10, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}",
+            "mbed-mesh-api.thread-config-ml-prefix": "{0xfd, 0x0, 0x0d, 0xb8, 0x0, 0x0, 0x0, 0x0}",
+            "mbed-mesh-api.thread-config-pskc": "{0xc8, 0xa6, 0x2e, 0xae, 0xf3, 0x68, 0xf3, 0x46, 0xa9, 0x9e, 0x57, 0x85, 0x98, 0x9d, 0x1c, 0xd0}"
+        }      
+    }
+}

--- a/main.cpp
+++ b/main.cpp
@@ -33,7 +33,7 @@
 		#include "ESP8266Interface.h"
 		ESP8266Interface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
     #endif
-#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
+#elif MBED_CONF_APP_NETWORK_INTERFACE == LWIP_ETHERNET
     #include "EthernetInterface.h"
     EthernetInterface eth;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
@@ -41,10 +41,14 @@
     #include "NanostackInterface.h"
     LoWPANNDInterface mesh;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
-    #define MESH
-    #include "NanostackInterface.h"
-    ThreadInterface mesh;
+#define MESH
+#include "NanostackInterface.h"
+ThreadInterface mesh;
+#elif MBED_CONF_APP_NETWORK_INTERFACE == NANOSTACK_ETHERNET
+#include "NanostackInterface.h"
+NanostackEthernetInterface eth;
 #endif
+
 
 #if defined(MESH)
 #if MBED_CONF_APP_MESH_RADIO_TYPE == ATMEL
@@ -395,7 +399,7 @@ Add MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES and MBEDTLS_TEST_NULL_ENTROPY in mbed_app
     output.printf("\n\rConnecting to WiFi..\r\n");
     connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD);
     network_interface = &wifi;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
+#elif MBED_CONF_APP_NETWORK_INTERFACE == LWIP_ETHERNET || MBED_CONF_APP_NETWORK_INTERFACE == NANOSTACK_ETHERNET
     output.printf("Using Ethernet\r\n");
     connect_success = eth.connect();
     network_interface = &eth;

--- a/simpleclient.h
+++ b/simpleclient.h
@@ -29,12 +29,14 @@
 #include "security.h"
 #include "mbed.h"
 
-#define ETHERNET        1
-#define WIFI            2
-#define MESH_LOWPAN_ND  3
-#define MESH_THREAD     4
-#define ATMEL           5
-#define MCR20           6
+#define ETHERNET                1
+#define LWIP_ETHERNET           1
+#define WIFI                    2
+#define MESH_LOWPAN_ND          3
+#define MESH_THREAD             4
+#define ATMEL                   5
+#define MCR20                   6
+#define NANOSTACK_ETHERNET      7
 
 #define STRINGIFY(s) #s
 
@@ -45,7 +47,9 @@
     #define MESH
 #endif
 
-#if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
+#if MBED_CONF_APP_NETWORK_INTERFACE == NANOSTACK_ETHERNET
+    M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::Nanostack_IPv6;
+#elif defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
     // Mesh is always IPV6 - also WiFi and ETH can be IPV6 if IPV6 is enabled
     M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv6;
 #else


### PR DESCRIPTION
Example modified to use new nanostack ethernet (ethernet_host.cfg) configuration (available in master).
Target is to reduce the ROM size.