### PR TITLE
mbed OS 5.3.0 (2nd try)

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#532da7133f7d51db958eacb2b5f13e7cf7feb81f
+https://github.com/ARMmbed/mbed-os/#c3b9436e12610acaab723f730ab15b48a539a5ac 


### PR DESCRIPTION
The official version of 5.3.0.