### PR TITLE
Use port=0 for randomization

### DIFF
--- a/simpleclient.h
+++ b/simpleclient.h
@@ -124,7 +124,7 @@ public:
                           void *handler=NULL) {
     // Randomizing listening port for Certificate mode connectivity
     _server_address = server_address;
-    uint16_t port = rand() % 65535 + 12345;
+    uint16_t port = 0; // Network interface will randomize with port 0
 
     // create mDS interface object, this is the base object everything else attaches to
     _interface = M2MInterfaceFactory::create_interface(*this,


### PR DESCRIPTION
Network stack will randomize the address once it's being set to port 0.
NOTE! Dependency on mbed OS 5.3, nanostack does the port randomization starting with mbedOS 5.3.