### PR TITLE
Network handling to net_client.cpp & clean simpleclient.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Your device can connect to mbed Device Connector via UDP or TCP binding mode. Th
 
 To change the binding mode:
 
-1. In the `simpleclient.h` file, find the parameter `SOCKET_MODE`. The default is `M2MInterface::UDP` for mesh and `M2MInterface::TCP` for others.
+1. In the `client_net.cpp` file, find the parameter `SOCKET_MODE`. The default is `M2MInterface::UDP` for mesh and `M2MInterface::TCP` for others.
 1. To switch to UDP, change it to `M2MInterface::UDP`.
 1. Rebuild and flash the application.
 
@@ -329,7 +329,7 @@ Using <Network Interface>
 Connected to Network successfully
 IP address xxx.xxx.xxx.xxx
 
-SOCKET_MODE : UDP
+SOCKET_MODE : TCP
 Connecting to coap://api.connector.mbed.com:5684
 
 ```

--- a/client_net.cpp
+++ b/client_net.cpp
@@ -1,0 +1,134 @@
+/*
+ * client_net.cpp
+ * 
+ * mbed-os-example-client - networking initializations here
+ *
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed.h"
+#include "simpleclient.h"
+
+// Check if using mesh networking, define helper
+#if MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
+    #define MESH
+#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
+    #define MESH
+#endif
+
+// Different bearer stacks
+#if MBED_CONF_APP_NETWORK_INTERFACE == WIFI
+    #if TARGET_UBLOX_EVK_ODIN_W2
+        #include "OdinWiFiInterface.h"
+        OdinWiFiInterface wifi;
+	#else
+		#include "ESP8266Interface.h"
+		ESP8266Interface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+    #endif
+#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
+    #include "EthernetInterface.h"
+    EthernetInterface eth;
+#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
+    #define MESH
+    #include "NanostackInterface.h"
+    LoWPANNDInterface mesh;
+#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
+    #define MESH
+    #include "NanostackInterface.h"
+    ThreadInterface mesh;
+#endif
+
+#if defined(MESH)
+    #if MBED_CONF_APP_MESH_RADIO_TYPE == ATMEL
+    #include "NanostackRfPhyAtmel.h"
+        NanostackRfPhyAtmel rf_phy(ATMEL_SPI_MOSI, ATMEL_SPI_MISO, ATMEL_SPI_SCLK, ATMEL_SPI_CS,
+                           ATMEL_SPI_RST, ATMEL_SPI_SLP, ATMEL_SPI_IRQ, ATMEL_I2C_SDA, ATMEL_I2C_SCL);
+#elif MBED_CONF_APP_MESH_RADIO_TYPE == MCR20
+    #include "NanostackRfPhyMcr20a.h"
+        NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, MCR20A_SPI_CS, MCR20A_SPI_RST, MCR20A_SPI_IRQ);
+    #endif //MBED_CONF_APP_RADIO_TYPE
+#endif //MESH
+
+
+#if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
+    // Mesh is always IPV6 - also WiFi and ETH can be IPV6 if IPV6 is enabled
+    M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv6;
+#else
+    // Everything else - we assume it's IPv4
+    M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv4;
+#endif
+
+//Select binding mode: UDP or TCP -- note - Mesh networking is IPv6 UDP ONLY
+#ifdef MESH
+ 	M2MInterface::BindingMode SOCKET_MODE = M2MInterface::UDP;
+    // Mesh does not have DNS, so must use direct IPV6 address
+    const char *MBED_SERVER_ADDRESS="coaps://[2607:f0d0:2601:52::20]:5684";
+#else
+	// WiFi or Ethernet supports both - TCP by default to avoid
+	// NAT problems, but UDP will also work - IF you configure
+	// your network right.
+    M2MInterface::BindingMode SOCKET_MODE = M2MInterface::TCP;
+    // This is address to mbed Device Connector, name based
+    // assume all other stacks support DNS properly
+    const char *MBED_SERVER_ADDRESS="coap://api.connector.mbed.com:5684";
+#endif
+
+/*
+ * client_net_init centralize the complexities of handling different
+ *                 network stacks
+ * IN: network interface ptr 
+ * OUT: int        0 connection succeeded
+ *                 -1 connection failed
+ *
+ */
+int client_net_init(NetworkInterface **network_interface, RawSerial *output) {
+    int connect_success;
+
+    *network_interface = NULL;
+    if(output) {
+    	output->printf("\r\nConnecting to ");
+    }
+#if MBED_CONF_APP_NETWORK_INTERFACE == WIFI
+    if(output) {
+        output->printf("WiFi");
+    }
+    connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+    *network_interface = &wifi;
+#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
+    if(output) {
+        output->printf("Ethernet");
+    }
+    connect_success = eth.connect();
+    *network_interface = &eth;
+#endif
+#ifdef MESH
+    if(output) {
+        output->printf("Mesh");
+    }
+    mesh.initialize(&rf_phy);
+    connect_success = mesh.connect();
+    *network_interface = &mesh;
+#endif
+
+#if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
+    if(output) {
+       output->printf(" in IPv6 mode\r\n");
+    }
+#else
+    if(output) { 
+        output->printf(" in IPv4 mode\r\n");
+    }
+#endif
+   return connect_success;
+}

--- a/client_net.h
+++ b/client_net.h
@@ -1,0 +1,29 @@
+/*
+ * client_net.h
+ *
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CLIENT_NET_H_
+#define CLIENT_NET_H_
+
+#include "mbed.h"
+#include "mbed-client/m2minterface.h"
+
+extern int client_net_init(NetworkInterface **network_interface, RawSerial *output);
+extern const char *MBED_SERVER_ADDRESS;
+extern M2MInterface::NetworkStack NETWORK_STACK;
+extern M2MInterface::BindingMode SOCKET_MODE;
+
+#endif /* CLIENT_NET_H_ */

--- a/simpleclient.cpp
+++ b/simpleclient.cpp
@@ -1,0 +1,313 @@
+/*
+ * simpleclient.cpp
+ *
+ *
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed-client/m2minterfacefactory.h"
+#include "mbed-client/m2mdevice.h"
+#include "mbed-client/m2minterfaceobserver.h"
+#include "mbed-client/m2minterface.h"
+#include "mbed-client/m2mobject.h"
+#include "mbed-client/m2mobjectinstance.h"
+#include "mbed-client/m2mresource.h"
+#include "mbed-client/m2mconfig.h"
+#include "mbed-client/m2mblockmessage.h"
+#include "mbed-trace/mbed_trace.h"
+#include "simpleclient.h"
+#include "security.h"
+#include "mbed.h"
+#include "client_net.h"
+
+
+#define TRACE_GROUP "sClt"
+
+
+// constructor for MbedClient object, initialize private variables
+MbedClient::MbedClient(struct MbedClientDevice device) :
+    _interface(NULL),
+    _register_security(NULL),
+    _object(NULL),
+    _bootstrapped(false),
+    _error(false),
+    _registered(false),
+    _unregistered(false),
+    _value(0),
+    _device(device)
+{
+    tr_info("MbedClient::MbedClient");
+}
+
+// de-constructor for MbedClient object, you can ignore this
+MbedClient::~MbedClient()
+{
+    if(_interface) {
+        delete _interface;
+    }
+    if(_register_security){
+        delete _register_security;
+    }
+}
+
+// debug printf function
+void MbedClient::trace_printer(const char* str)
+{
+    printf("\r\n%s\r\n", str);
+}
+
+/*
+ *  Creates M2MInterface using which endpoint can
+ *  setup its name, resource type, life time, connection mode,
+ *  Currently only LwIPv4 is supported.
+*/
+void MbedClient::create_interface(const char *server_address,
+                                  void *handler)
+{
+    // Randomizing listening port for Certificate mode connectivity
+    _server_address = server_address;
+    uint16_t port = 0; // Network interface will randomize with port 0
+
+    // create mDS interface object, this is the base object everything else attaches to
+    _interface = M2MInterfaceFactory::create_interface(*this,
+                                                      MBED_ENDPOINT_NAME,       // endpoint name string
+                                                      "test",                   // endpoint type string
+                                                      100,                      // lifetime
+                                                      port,                     // listen port
+                                                      MBED_DOMAIN,              // domain string
+                                                      SOCKET_MODE,              // binding mode
+                                                      NETWORK_STACK,            // network stack
+                                                      "");                      // context address string
+    const char *binding_mode = (SOCKET_MODE == M2MInterface::UDP) ? "UDP" : "TCP";
+    printf("\r\nSOCKET_MODE : %s\r\n", binding_mode);
+    printf("Connecting to %s\r\n", server_address);
+
+    if(_interface) {
+        _interface->set_platform_network_handler(handler);
+    }
+}
+
+/*
+ *  check private variable to see if the registration was sucessful or not
+*/
+bool MbedClient::register_successful()
+{
+        return _registered;
+}
+
+/*
+ *  check private variable to see if un-registration was sucessful or not
+*/
+bool MbedClient::unregister_successful()
+{
+    return _unregistered;
+}
+
+/*
+ *  Creates register server object with mbed device server address and other parameters
+ *  required for client to connect to mbed device server.
+*/
+M2MSecurity* MbedClient::create_register_object()
+{
+    // create security object using the interface factory.
+    // this will generate a security ObjectID and ObjectInstance
+    M2MSecurity *security = M2MInterfaceFactory::create_security(M2MSecurity::M2MServer);
+
+    // make sure security ObjectID/ObjectInstance was created successfully
+    if(security) {
+		// Add ResourceID's and values to the security ObjectID/ObjectInstance
+		security->set_resource_value(M2MSecurity::M2MServerUri, _server_address);
+		security->set_resource_value(M2MSecurity::SecurityMode, M2MSecurity::Certificate);
+		security->set_resource_value(M2MSecurity::ServerPublicKey, SERVER_CERT, sizeof(SERVER_CERT));
+		security->set_resource_value(M2MSecurity::PublicKey, CERT, sizeof(CERT));
+		security->set_resource_value(M2MSecurity::Secretkey, KEY, sizeof(KEY));
+	}
+	return security;
+}
+
+/*
+* Creates device object which contains mandatory resources linked with
+* device endpoint.
+*/
+M2MDevice* MbedClient::create_device_object()
+{
+	// create device objectID/ObjectInstance
+	M2MDevice *device = M2MInterfaceFactory::create_device();
+	// make sure device object was created successfully
+	if(device) {
+		// add resourceID's to device objectID/ObjectInstance
+		device->create_resource(M2MDevice::Manufacturer, _device.Manufacturer);
+		device->create_resource(M2MDevice::DeviceType, _device.Type);
+		device->create_resource(M2MDevice::ModelNumber, _device.ModelNumber);
+		device->create_resource(M2MDevice::SerialNumber, _device.SerialNumber);
+	}
+	return device;
+}
+
+/*
+* register an object
+*/
+void MbedClient::test_register(M2MSecurity *register_object, M2MObjectList object_list)
+{
+	if(_interface) {
+		// Register function
+		_interface->register_object(register_object, object_list);
+	}
+}
+
+/*
+* unregister all objects
+*/
+void MbedClient::test_unregister()
+{
+	if(_interface) {
+		// Unregister function
+		_interface->unregister_object(NULL); // NULL will unregister all objects
+	}
+}
+
+/* Callback from mbed client stack when the bootstrap
+ * is successful, it returns the mbed Device Server object
+ * which will be used for registering the resources to
+ * mbed Device server.
+ */
+void MbedClient::bootstrap_done(M2MSecurity *server_object)
+{
+	if(server_object) {
+		_bootstrapped = true;
+		_error = false;
+		 tr_debug("Bootstrapped");
+	}
+}
+
+/* Callback from mbed client stack when the registration
+ * is successful, it returns the mbed Device Server object
+ * to which the resources are registered and registered objects.
+ */
+void MbedClient::object_registered(M2MSecurity */*security_object*/, const M2MServer &/*server_object*/)
+{
+	_registered = true;
+	_unregistered = false;
+	this->trace_printer("Registered object successfully!");
+}
+
+    //Callback from mbed client stack when the unregistration
+    // is successful, it returns the mbed Device Server object
+    // to which the resources were unregistered.
+void MbedClient::object_unregistered(M2MSecurity */*server_object*/)
+{
+	this->trace_printer("Unregistered Object Successfully");
+	_unregistered = true;
+	_registered = false;
+}
+
+/*
+* Callback from mbed client stack when registration is updated
+*/
+void MbedClient::registration_updated(M2MSecurity */*security_object*/, const M2MServer & /*server_object*/)
+{
+	/* The registration is updated automatically and frequently by the
+	*  mbed client stack. This print statement is turned off because it
+	*  tends to happen alot.
+	*/
+	tr_debug("\r\nRegistration Updated\r\n");
+}
+
+/* Callback from mbed client stack if any error is encountered
+ * during any of the LWM2M operations. Error type is passed in
+ * the callback.
+ */
+void MbedClient::error(M2MInterface::Error error)
+{
+	_error = true;
+	switch(error){
+		case M2MInterface::AlreadyExists:
+			tr_debug("[ERROR:] M2MInterface::AlreadyExist");
+			break;
+		case M2MInterface::BootstrapFailed:
+			tr_debug("[ERROR:] M2MInterface::BootstrapFailed");
+			break;
+		case M2MInterface::InvalidParameters:
+			tr_debug("[ERROR:] M2MInterface::InvalidParameters");
+			break;
+		case M2MInterface::NotRegistered:
+			tr_debug("[ERROR:] M2MInterface::NotRegistered");
+			break;
+		case M2MInterface::Timeout:
+			tr_debug("[ERROR:] M2MInterface::Timeout");
+			break;
+		case M2MInterface::NetworkError:
+			tr_debug("[ERROR:] M2MInterface::NetworkError");
+			break;
+		case M2MInterface::ResponseParseFailed:
+			tr_debug("[ERROR:] M2MInterface::ResponseParseFailed");
+			break;
+		case M2MInterface::UnknownError:
+			tr_debug("[ERROR:] M2MInterface::UnknownError");
+			break;
+		case M2MInterface::MemoryFail:
+			tr_debug("[ERROR:] M2MInterface::MemoryFail");
+			break;
+		case M2MInterface::NotAllowed:
+			tr_debug("[ERROR:] M2MInterface::NotAllowed");
+			break;
+		case M2MInterface::SecureConnectionFailed:
+			tr_debug("[ERROR:] M2MInterface::SecureConnectionFailed");
+			break;
+		case M2MInterface::DnsResolvingFailed:
+			tr_debug("[ERROR:] M2MInterface::DnsResolvingFailed");
+			break;
+
+		default:
+			tr_debug("[ERROR:] Unknown error met in simpleclient.cpp");
+			break;
+	}
+ }
+
+/* Callback from mbed client stack if any value has changed
+*  during PUT operation. Object and its type is passed in
+*  the callback.
+*  BaseType enum from m2mbase.h
+*       Object = 0x0, Resource = 0x1, ObjectInstance = 0x2, ResourceInstance = 0x3
+*/
+void MbedClient::value_updated(M2MBase *base, M2MBase::BaseType type)
+{
+	tr_debug("\r\nPUT Request Received!");
+	tr_debug("\r\nName :'%s', \r\nType : '%d' (0 for Object, 1 for Resource), \r\nType : '%s'\r\n",
+		   base->name(),
+		   type,
+		   base->resource_type()
+		   );
+}
+
+/*
+* update the registration period
+*/
+void MbedClient::test_update_register()
+{
+	if (_registered) {
+		_interface->update_registration(_register_security, 100);
+	}
+}
+
+/*
+* manually configure the security object private variable
+*/
+void  MbedClient::set_register_object(M2MSecurity *register_object)
+{
+	if (_register_security == NULL) {
+		_register_security = register_object;
+	}
+}

--- a/simpleclient.h
+++ b/simpleclient.h
@@ -28,6 +28,7 @@
 #include "mbed-client/m2mblockmessage.h"
 #include "security.h"
 #include "mbed.h"
+#include "client_net.h"
 
 #define ETHERNET        1
 #define WIFI            2
@@ -37,32 +38,6 @@
 #define MCR20           6
 
 #define STRINGIFY(s) #s
-
-// Check if using mesh networking, define helper
-#if MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
-    #define MESH
-#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
-    #define MESH
-#endif
-
-#if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
-    // Mesh is always IPV6 - also WiFi and ETH can be IPV6 if IPV6 is enabled
-    M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv6;
-#else
-    // Everything else - we assume it's IPv4
-    M2MInterface::NetworkStack NETWORK_STACK = M2MInterface::LwIP_IPv4;
-#endif
-
-//Select binding mode: UDP or TCP -- note - Mesh networking is IPv6 UDP ONLY
-#ifdef MESH
-    M2MInterface::BindingMode SOCKET_MODE = M2MInterface::UDP;
-#else
-    // WiFi or Ethernet supports both - TCP by default to avoid
-    // NAT problems, but UDP will also work - IF you configure
-    // your network right.
-    M2MInterface::BindingMode SOCKET_MODE = M2MInterface::TCP;
-#endif
-
 
 // MBED_DOMAIN and MBED_ENDPOINT_NAME come
 // from the security.h file copied from connector.mbed.com
@@ -88,32 +63,13 @@ class MbedClient: public M2MInterfaceObserver {
 public:
 
     // constructor for MbedClient object, initialize private variables
-    MbedClient(struct MbedClientDevice device) {
-        _interface = NULL;
-        _bootstrapped = false;
-        _error = false;
-        _registered = false;
-        _unregistered = false;
-        _register_security = NULL;
-        _value = 0;
-        _object = NULL;
-        _device = device;
-    }
+	MbedClient(struct MbedClientDevice device);
 
     // de-constructor for MbedClient object, you can ignore this
-    ~MbedClient() {
-        if(_interface) {
-            delete _interface;
-        }
-        if(_register_security){
-            delete _register_security;
-        }
-    }
+    ~MbedClient();
 
     // debug printf function
-    void trace_printer(const char* str) {
-        printf("\r\n%s\r\n", str);
-    }
+    void trace_printer(const char* str);
 
     /*
     *  Creates M2MInterface using which endpoint can
@@ -121,192 +77,63 @@ public:
     *  Currently only LwIPv4 is supported.
     */
     void create_interface(const char *server_address,
-                          void *handler=NULL) {
-    // Randomizing listening port for Certificate mode connectivity
-    _server_address = server_address;
-    uint16_t port = 0; // Network interface will randomize with port 0
-
-    // create mDS interface object, this is the base object everything else attaches to
-    _interface = M2MInterfaceFactory::create_interface(*this,
-                                                      MBED_ENDPOINT_NAME,       // endpoint name string
-                                                      "test",                   // endpoint type string
-                                                      100,                      // lifetime
-                                                      port,                     // listen port
-                                                      MBED_DOMAIN,              // domain string
-                                                      SOCKET_MODE,              // binding mode
-                                                      NETWORK_STACK,            // network stack
-                                                      "");                      // context address string
-    const char *binding_mode = (SOCKET_MODE == M2MInterface::UDP) ? "UDP" : "TCP";
-    printf("\r\nSOCKET_MODE : %s\r\n", binding_mode);
-    printf("Connecting to %s\r\n", server_address);
-
-    if(_interface) {
-        _interface->set_platform_network_handler(handler);
-    }
-
-    }
-
+                          void *handler=NULL);
     /*
     *  check private variable to see if the registration was sucessful or not
     */
-    bool register_successful() {
-        return _registered;
-    }
+    bool register_successful();
 
     /*
     *  check private variable to see if un-registration was sucessful or not
     */
-    bool unregister_successful() {
-        return _unregistered;
-    }
+    bool unregister_successful();
 
     /*
     *  Creates register server object with mbed device server address and other parameters
     *  required for client to connect to mbed device server.
     */
-    M2MSecurity* create_register_object() {
-        // create security object using the interface factory.
-        // this will generate a security ObjectID and ObjectInstance
-        M2MSecurity *security = M2MInterfaceFactory::create_security(M2MSecurity::M2MServer);
-
-        // make sure security ObjectID/ObjectInstance was created successfully
-        if(security) {
-            // Add ResourceID's and values to the security ObjectID/ObjectInstance
-            security->set_resource_value(M2MSecurity::M2MServerUri, _server_address);
-            security->set_resource_value(M2MSecurity::SecurityMode, M2MSecurity::Certificate);
-            security->set_resource_value(M2MSecurity::ServerPublicKey, SERVER_CERT, sizeof(SERVER_CERT) - 1);
-            security->set_resource_value(M2MSecurity::PublicKey, CERT, sizeof(CERT) - 1);
-            security->set_resource_value(M2MSecurity::Secretkey, KEY, sizeof(KEY) - 1);
-        }
-        return security;
-    }
+    M2MSecurity* create_register_object();
 
     /*
     * Creates device object which contains mandatory resources linked with
     * device endpoint.
     */
-    M2MDevice* create_device_object() {
-        // create device objectID/ObjectInstance
-        M2MDevice *device = M2MInterfaceFactory::create_device();
-        // make sure device object was created successfully
-        if(device) {
-            // add resourceID's to device objectID/ObjectInstance
-            device->create_resource(M2MDevice::Manufacturer, _device.Manufacturer);
-            device->create_resource(M2MDevice::DeviceType, _device.Type);
-            device->create_resource(M2MDevice::ModelNumber, _device.ModelNumber);
-            device->create_resource(M2MDevice::SerialNumber, _device.SerialNumber);
-        }
-        return device;
-    }
-
+    M2MDevice* create_device_object();
     /*
     * register an object
     */
-    void test_register(M2MSecurity *register_object, M2MObjectList object_list){
-        if(_interface) {
-            // Register function
-            _interface->register_object(register_object, object_list);
-        }
-    }
+    void test_register(M2MSecurity *register_object, M2MObjectList object_list);
 
     /*
     * unregister all objects
     */
-    void test_unregister() {
-        if(_interface) {
-            // Unregister function
-            _interface->unregister_object(NULL); // NULL will unregister all objects
-        }
-    }
+    void test_unregister();
 
     //Callback from mbed client stack when the bootstrap
     // is successful, it returns the mbed Device Server object
     // which will be used for registering the resources to
     // mbed Device server.
-    void bootstrap_done(M2MSecurity *server_object){
-        if(server_object) {
-            _bootstrapped = true;
-            _error = false;
-            trace_printer("Bootstrapped");
-        }
-    }
+    void bootstrap_done(M2MSecurity *server_object);
 
     //Callback from mbed client stack when the registration
     // is successful, it returns the mbed Device Server object
     // to which the resources are registered and registered objects.
-    void object_registered(M2MSecurity */*security_object*/, const M2MServer &/*server_object*/){
-        _registered = true;
-        _unregistered = false;
-        trace_printer("Registered object successfully!");
-    }
+    void object_registered(M2MSecurity */*security_object*/, const M2MServer &/*server_object*/);
 
     //Callback from mbed client stack when the unregistration
     // is successful, it returns the mbed Device Server object
     // to which the resources were unregistered.
-    void object_unregistered(M2MSecurity */*server_object*/){
-        trace_printer("Unregistered Object Successfully");
-        _unregistered = true;
-        _registered = false;
-    }
+    void object_unregistered(M2MSecurity */*server_object*/);
 
     /*
     * Callback from mbed client stack when registration is updated
     */
-    void registration_updated(M2MSecurity */*security_object*/, const M2MServer & /*server_object*/){
-        /* The registration is updated automatically and frequently by the
-        *  mbed client stack. This print statement is turned off because it
-        *  tends to happen alot.
-        */
-        //trace_printer("\r\nRegistration Updated\r\n");
-    }
+    void registration_updated(M2MSecurity */*security_object*/, const M2MServer & /*server_object*/);
 
     // Callback from mbed client stack if any error is encountered
     // during any of the LWM2M operations. Error type is passed in
     // the callback.
-    void error(M2MInterface::Error error){
-        _error = true;
-        switch(error){
-            case M2MInterface::AlreadyExists:
-                trace_printer("[ERROR:] M2MInterface::AlreadyExist");
-                break;
-            case M2MInterface::BootstrapFailed:
-                trace_printer("[ERROR:] M2MInterface::BootstrapFailed");
-                break;
-            case M2MInterface::InvalidParameters:
-                trace_printer("[ERROR:] M2MInterface::InvalidParameters");
-                break;
-            case M2MInterface::NotRegistered:
-                trace_printer("[ERROR:] M2MInterface::NotRegistered");
-                break;
-            case M2MInterface::Timeout:
-                trace_printer("[ERROR:] M2MInterface::Timeout");
-                break;
-            case M2MInterface::NetworkError:
-                trace_printer("[ERROR:] M2MInterface::NetworkError");
-                break;
-            case M2MInterface::ResponseParseFailed:
-                trace_printer("[ERROR:] M2MInterface::ResponseParseFailed");
-                break;
-            case M2MInterface::UnknownError:
-                trace_printer("[ERROR:] M2MInterface::UnknownError");
-                break;
-            case M2MInterface::MemoryFail:
-                trace_printer("[ERROR:] M2MInterface::MemoryFail");
-                break;
-            case M2MInterface::NotAllowed:
-                trace_printer("[ERROR:] M2MInterface::NotAllowed");
-                break;
-            case M2MInterface::SecureConnectionFailed:
-                trace_printer("[ERROR:] M2MInterface::SecureConnectionFailed");
-                break;
-            case M2MInterface::DnsResolvingFailed:
-                trace_printer("[ERROR:] M2MInterface::DnsResolvingFailed");
-                break;
-
-            default:
-                break;
-        }
-    }
+    void error(M2MInterface::Error error);
 
     /* Callback from mbed client stack if any value has changed
     *  during PUT operation. Object and its type is passed in
@@ -314,49 +141,32 @@ public:
     *  BaseType enum from m2mbase.h
     *       Object = 0x0, Resource = 0x1, ObjectInstance = 0x2, ResourceInstance = 0x3
     */
-    void value_updated(M2MBase *base, M2MBase::BaseType type) {
-        printf("\r\nPUT Request Received!");
-        printf("\r\nName :'%s', \r\nPath : '%s', \r\nType : '%d' (0 for Object, 1 for Resource), \r\nType : '%s'\r\n",
-               base->name(),
-               base->uri_path(),
-               type,
-               base->resource_type()
-               );
-    }
+    void value_updated(M2MBase *base, M2MBase::BaseType type);
 
     /*
     * update the registration period
     */
-    void test_update_register() {
-        if (_registered) {
-            _interface->update_registration(_register_security, 100);
-        }
-    }
+    void test_update_register();
 
     /*
     * manually configure the security object private variable
     */
-   void set_register_object(M2MSecurity *register_object) {
-        if (_register_security == NULL) {
-            _register_security = register_object;
-        }
-    }
+   void set_register_object(M2MSecurity *register_object);
 
 private:
-
-    /*
-    *  Private variables used in class
-    */
-    M2MInterface    	     *_interface;
-    M2MSecurity              *_register_security;
-    M2MObject                *_object;
-    volatile bool            _bootstrapped;
-    volatile bool            _error;
-    volatile bool            _registered;
-    volatile bool            _unregistered;
-    int                      _value;
-    struct MbedClientDevice  _device;
-    String                   _server_address;
+   /*
+   *  Private variables used in class
+   */
+   M2MInterface             *_interface;
+   M2MSecurity              *_register_security;
+   M2MObject                *_object;
+   volatile bool            _bootstrapped;
+   volatile bool            _error;
+   volatile bool            _registered;
+   volatile bool            _unregistered;
+   int                      _value;
+   struct MbedClientDevice  _device;
+   String                   _server_address;
 };
 
 #endif // __SIMPLECLIENT_H__


### PR DESCRIPTION
Attempt to simplify main.cpp:
-   Clean up main.cpp from network related issued - to new files.
-   Cleanup simpleclient.h so that it is a clean header file
    and implementation is in simpleclient.cpp.
- Return with 0 in main.ccp if no network address given.
