### PR TITLE
Mesh to use channel 12

### DIFF
--- a/configs/mesh_6lowpan.json
+++ b/configs/mesh_6lowpan.json
@@ -14,7 +14,7 @@
         "*": {
             "target.features_add": ["NANOSTACK", "LOWPAN_ROUTER", "COMMON_PAL"],
             "mbed-mesh-api.6lowpan-nd-channel-page": 0,
-            "mbed-mesh-api.6lowpan-nd-channel": 18,
+            "mbed-mesh-api.6lowpan-nd-channel": 12,
             "mbed-trace.enable": 0
         }
     }

--- a/configs/mesh_thread.json
+++ b/configs/mesh_thread.json
@@ -13,8 +13,8 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["NANOSTACK", "THREAD_ROUTER", "COMMON_PAL"],
-            "mbed-mesh-api.thread-config-channel": 18,
-            "mbed-mesh-api.thread-config-panid": "0xBAAB",
+            "mbed-mesh-api.thread-config-channel": 12,
+            "mbed-mesh-api.thread-config-panid": "0xDEFA",
             "mbed-trace.enable": 0
         }
     }


### PR DESCRIPTION
The included firmware binaries for mesh are hard-coded for channel 12,
so better use that in the JSONs as well.