### PR TITLE
Fix the cert len

### DIFF
--- a/simpleclient.h
+++ b/simpleclient.h
@@ -174,9 +174,9 @@ public:
             // Add ResourceID's and values to the security ObjectID/ObjectInstance
             security->set_resource_value(M2MSecurity::M2MServerUri, _server_address);
             security->set_resource_value(M2MSecurity::SecurityMode, M2MSecurity::Certificate);
-            security->set_resource_value(M2MSecurity::ServerPublicKey, SERVER_CERT, sizeof(SERVER_CERT));
-            security->set_resource_value(M2MSecurity::PublicKey, CERT, sizeof(CERT));
-            security->set_resource_value(M2MSecurity::Secretkey, KEY, sizeof(KEY));
+            security->set_resource_value(M2MSecurity::ServerPublicKey, SERVER_CERT, sizeof(SERVER_CERT) - 1);
+            security->set_resource_value(M2MSecurity::PublicKey, CERT, sizeof(CERT) - 1);
+            security->set_resource_value(M2MSecurity::Secretkey, KEY, sizeof(KEY) - 1);
         }
         return security;
     }


### PR DESCRIPTION
The set_resource_value function will automatically add the null termination ('\0') so to avoid getting two of them added - 1 to after the sizeof.