### PR TITLE
UBLOX ethernet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ The application:
  * NUCLEO_F429ZI + ATMEL AT233 15.4 shield (mesh `LOWPAN_ROUTER` mode)
  * K64F (Ethernet)
  * NUCLEO_F429ZI (Ethernet)
- * UBLOX_EVK_ODIN_W2 (WiFi - ethernet does not seem to work)
+ * UBLOX_EVK_ODIN_W2 (WiFi & Ethernet - use the supplied `configs/eth_v4.json` for Ethernet)
  * K64F + GROVE SEEED shield (Wifi)
  * NUCLEO_F429ZI + GROVE SEEED shield (Wifi)
 
 Apart from this, this example can work on other mbed OS supported hardware boards which support any of the given network interface including Ethernet, WiFi, Mesh (6LoWPAN) or Thread, provided the configuration fulfills condition that the target hardware has TLS entropy implemented for it and the complete example configuration of mbed Client, selected network interface and mbed OS components fits into hardware's given memory size (Flash size and RAM size). 
+
+To see how different targets are built please see the supplied `build_all.sh script`.
 
 ## Requirements for non-K64F boards
 

--- a/configs/eth_v4.json
+++ b/configs/eth_v4.json
@@ -12,6 +12,9 @@
             "lwip.ipv4-enabled": true,
             "lwip.ipv6-enabled": false,
             "mbed-trace.enable": 0
+        },
+            "UBLOX_EVK_ODIN_W2": {
+            "target.device_has_remove": ["EMAC"]
         }
     }
 }

--- a/configs/eth_v6.json
+++ b/configs/eth_v6.json
@@ -12,6 +12,9 @@
             "lwip.ipv4-enabled": false,
             "lwip.ipv6-enabled": true,
             "mbed-trace.enable": 0
+        },
+            "UBLOX_EVK_ODIN_W2": {
+            "target.device_has_remove": ["EMAC"]
         }
     }
 }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -40,6 +40,9 @@
         "NUCLEO_F411RE": {
             "wifi-tx": "PA_11",
             "wifi-rx": "PA_12"
+        },
+        "UBLOX_EVK_ODIN_W2": {
+        "target.device_has_remove": ["EMAC"]
         }
     }
 }


### PR DESCRIPTION
You can get the ethernet working on the UBLOX, if you modify the
mbed_app.json - eth configs changed to match the need (you need
to drop the "EMAC" in case of UBLOX).

cp configs/eth_v4.json mbed_app.json
cp configs/eth-wifi-mbedignore .mbedignore
mbed compile -m UBLOX_EVK_ODIN_W2

yields a working ethernet binary for UBLOX.