### PR TITLE
Integrate easy-connect, fix serial, fix warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,15 +323,17 @@ The application prints debug messages over the serial port, so you can monitor i
 After connecting, you should see messages about connecting to mbed Device Connector:
 
 ```
-Starting mbed Client example...
-Using <Network Interface>
+Starting mbed Client example in IPv4 mode
+[EasyConnect] Using Ethernet
+[EasyConnect] Connected to Network successfully
+[EasyConnect] IP address  192.168.8.110
+[EasyConnect] MAC address 5c:cf:7f:86:de:bf
 
-Connected to Network successfully
-IP address xxx.xxx.xxx.xxx
+SOCKET_MODE : TCP
 
-SOCKET_MODE : UDP
 Connecting to coap://api.connector.mbed.com:5684
 
+Registered object succesfully!
 ```
 
 <span class="notes">**Note:** Device name is the endpoint name you will need later on when [testing the application](https://github.com/ARMmbed/mbed-os-example-client#testing-the-application).</span>

--- a/atmel-rf-driver.lib
+++ b/atmel-rf-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/armmbed/atmel-rf-driver/#57f22763f4d3649d4ac0b1df1f568f4cc45e491a

--- a/build_all.sh
+++ b/build_all.sh
@@ -4,37 +4,52 @@ set -e
 TOOL=GCC_ARM
 
 echo Compiling with $TOOL
+echo Ethernet v4
 cp configs/eth_v4.json ./mbed_app.json
 cp configs/eth-wifi-mbedignore ./.mbedignore
 mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/GCC_ARM/mbed-os-example-client.bin k64f-$TOOL-eth-v4.bin
+cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-eth-v4.bin
 mbed compile -m NUCLEO_F439ZI -t $TOOL
-cp ./BUILD/NUCLEO_F439ZI/GCC_ARM/mbed-os-example-client.bin f439zi-$TOOL-eth-v4.bin
+cp ./BUILD/NUCLEO_F439ZI/$TOOL/mbed-os-example-client.bin f439zi-$TOOL-eth-v4.bin
+mbed compile -m UBLOX_EVK_ODIN_W2 -t $TOOL
+cp ./BUILD/UBLOX_EVK_ODIN_W2/$TOOL/mbed-os-example-client.bin ublox-odin-$TOOL-eth-v4.bin
 
+echo Ethernet v6
 cp configs/eth_v6.json ./mbed_app.json
 cp configs/eth-wifi-mbedignore ./.mbedignore
 mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/GCC_ARM/mbed-os-example-client.bin k64f-$TOOL-eth-v6.bin
+cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-eth-v6.bin
 mbed compile -m NUCLEO_F439ZI -t $TOOL
-cp ./BUILD/NUCLEO_F439ZI/GCC_ARM/mbed-os-example-client.bin f439zi-$TOOL-eth-v4.bin
+cp ./BUILD/NUCLEO_F439ZI/$TOOL/mbed-os-example-client.bin f439zi-$TOOL-eth-v4.bin
+mbed compile -m UBLOX_EVK_ODIN_W2 -t $TOOL
+cp ./BUILD/UBLOX_EVK_ODIN_W2/$TOOL/mbed-os-example-client.bin ublox-odin-$TOOL-eth-v6.bin
 
-cp configs/wifi_v4.json ./mbed_app.json
+echo WIFI - ESP8266 
+cp configs/wifi_esp8266_v4.json ./mbed_app.json
 cp configs/eth-wifi-mbedignore ./.mbedignore
 mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/GCC_ARM/mbed-os-example-client.bin k64f-$TOOL-wifi-v4.bin
-mbed compile -m UBLOX_EVK_ODIN_W2 -t $TOOL
-cp ./BUILD/UBLOX_EVK_ODIN_W2/GCC_ARM/mbed-os-example-client.bin ublox-odin-$TOOL-wifi-v4.bin
+cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-esp-wifi-v4.bin
+mbed compile -m NUCLEO_F439ZI -t $TOOL
+cp ./BUILD/NUCLEO_F439ZI/$TOOL/mbed-os-example-client.bin f439zi-$TOOL-esp-wifi-v4.bin
 
+echo WIFI - ODIN for UBLOX_EVK_ODIN_W2
+cp configs/wifi_odin_v4.json ./mbed_app.json
+cp configs/eth-wifi-mbedignore ./.mbedignore
+mbed compile -m UBLOX_EVK_ODIN_W2 -t $TOOL
+cp ./BUILD/UBLOX_EVK_ODIN_W2/$TOOL/mbed-os-example-client.bin ublox-odin-$TOOL-wifi-v4.bin
+
+echo 6-Lowpan builds
 cp configs/mesh_6lowpan.json ./mbed_app.json
 cp configs/mesh-mbedignore ./.mbedignore
 mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/GCC_ARM/mbed-os-example-client.bin k64f-$TOOL-6lowpan.bin
+cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-6lowpan.bin
 mbed compile -m NUCLEO_F439ZI -t $TOOL
-cp ./BUILD/NUCLEO_F439ZI/GCC_ARM/mbed-os-example-client.bin f439zi-$TOOL-6lowpan.bin
+cp ./BUILD/NUCLEO_F439ZI/$TOOL/mbed-os-example-client.bin f439zi-$TOOL-6lowpan.bin
 
+echo Thread builds
 cp configs/mesh_thread.json ./mbed_app.json
 cp configs/mesh-mbedignore ./.mbedignore
 mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/GCC_ARM/mbed-os-example-client.bin k64f-$TOOL-Thread.bin
+cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-Thread.bin
 mbed compile -m NUCLEO_F439ZI -t $TOOL
-cp ./BUILD/NUCLEO_F439ZI/GCC_ARM/mbed-os-example-client.bin f439zi-$TOOL-Thread.bin
+cp ./BUILD/NUCLEO_F439ZI/$TOOL/mbed-os-example-client.bin f439zi-$TOOL-Thread.bin

--- a/configs/eth-wifi-mbedignore
+++ b/configs/eth-wifi-mbedignore
@@ -1,3 +1,3 @@
-atmel-rf-driver/*
-mcr20a-rf-driver/*
+easy-connect/atmel-rf-driver/*
+easy-connect/mcr20a-rf-driver/*
 

--- a/configs/eth_v4.json
+++ b/configs/eth_v4.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI,MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
             "value": "ETHERNET"
         }
     },
@@ -9,6 +9,8 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["LWIP", "COMMON_PAL"],
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
             "lwip.ipv4-enabled": true,
             "lwip.ipv6-enabled": false,
             "mbed-trace.enable": 0

--- a/configs/eth_v6.json
+++ b/configs/eth_v6.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI,MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
             "value": "ETHERNET"
         }
     },
@@ -9,6 +9,8 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["LWIP", "COMMON_PAL"],
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
             "lwip.ipv4-enabled": false,
             "lwip.ipv6-enabled": true,
             "mbed-trace.enable": 0

--- a/configs/mesh-mbedignore
+++ b/configs/mesh-mbedignore
@@ -1,1 +1,1 @@
-esp8266-driver/*
+easy-connect/esp8266-driver/*

--- a/configs/mesh_6lowpan.json
+++ b/configs/mesh_6lowpan.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI,MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
             "value": "MESH_LOWPAN_ND"
         },
         "mesh_radio_type": {
@@ -13,6 +13,8 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["NANOSTACK", "LOWPAN_ROUTER", "COMMON_PAL"],
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
             "mbed-mesh-api.6lowpan-nd-channel-page": 0,
             "mbed-mesh-api.6lowpan-nd-channel": 12,
             "mbed-trace.enable": 0

--- a/configs/mesh_thread.json
+++ b/configs/mesh_thread.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI,MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
             "value": "MESH_THREAD"
         },
         "mesh_radio_type": {
@@ -13,6 +13,8 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["NANOSTACK", "THREAD_ROUTER", "COMMON_PAL"],
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
             "mbed-mesh-api.thread-config-channel": 12,
             "mbed-mesh-api.thread-config-panid": "0xDEFA",
             "mbed-trace.enable": 0

--- a/configs/wifi_esp8266_v4.json
+++ b/configs/wifi_esp8266_v4.json
@@ -1,8 +1,8 @@
 {
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI,MESH_LOWPAN_ND,MESH_THREAD",
-            "value": "WIFI"
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
+            "value": "WIFI_ESP8266"
         },
         "wifi-ssid": {
             "help": "WiFi SSID",
@@ -25,6 +25,8 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["LWIP", "COMMON_PAL"],
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
             "lwip.ipv4-enabled": true,
             "lwip.ipv6-enabled": false,
             "mbed-trace.enable": 0

--- a/configs/wifi_odin_v4.json
+++ b/configs/wifi_odin_v4.json
@@ -2,11 +2,7 @@
     "config": {
         "network-interface":{
             "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
-            "value": "ETHERNET"
-        },
-        "mesh_radio_type": {
-        	"help": "options are ATMEL, MCR20",
-        	"value": "ATMEL"
+            "value": "WIFI_ODIN"
         },
         "wifi-ssid": {
             "help": "WiFi SSID",
@@ -28,11 +24,11 @@
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
     "target_overrides": {
         "*": {
-            "target.features_add": ["NANOSTACK", "LOWPAN_ROUTER", "COMMON_PAL"],
+            "target.features_add": ["LWIP", "COMMON_PAL"],
             "platform.stdio-baud-rate": 115200,
-            "platform.stdio-convert-newlines": true,
-            "mbed-mesh-api.6lowpan-nd-channel-page": 0,
-            "mbed-mesh-api.6lowpan-nd-channel": 12,
+            "platform.stdio-convert-newlines":true,
+            "lwip.ipv4-enabled": true,
+            "lwip.ipv6-enabled": false,
             "mbed-trace.enable": 0
         },
         "NUCLEO_F401RE": {
@@ -42,9 +38,6 @@
         "NUCLEO_F411RE": {
             "wifi-tx": "PA_11",
             "wifi-rx": "PA_12"
-        },
-        "UBLOX_EVK_ODIN_W2": {
-        "target.device_has_remove": ["EMAC"]
         }
     }
 }

--- a/configs/wifi_v4.json
+++ b/configs/wifi_v4.json
@@ -1,0 +1,43 @@
+{
+    "config": {
+        "network-interface":{
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
+            "value": "WIFI_ESP8266"
+        },
+        "wifi-ssid": {
+            "help": "WiFi SSID",
+            "value": "\"SSID\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"Password\""
+        },
+        "wifi-tx": {
+            "help": "TX pin for serial connection to external device",
+            "value": "D1"
+        },
+        "wifi-rx": {
+            "help": "RX pin for serial connection to external device",
+            "value": "D0"
+        }
+    },
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
+    "target_overrides": {
+        "*": {
+            "target.features_add": ["LWIP", "COMMON_PAL"],
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
+            "lwip.ipv4-enabled": true,
+            "lwip.ipv6-enabled": false,
+            "mbed-trace.enable": 0
+        },
+        "NUCLEO_F401RE": {
+            "wifi-tx": "PA_11",
+            "wifi-rx": "PA_12"
+        },
+        "NUCLEO_F411RE": {
+            "wifi-tx": "PA_11",
+            "wifi-rx": "PA_12"
+        }
+    }
+}

--- a/easy-connect.lib
+++ b/easy-connect.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/easy-connect.git/#a913964341394430cd3997c6f2950f93ba1d75c8

--- a/esp8266-driver.lib
+++ b/esp8266-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/esp8266-driver/#86ed47c8bf40c86fdc569c7e678a8944f5e01c2a

--- a/main.cpp
+++ b/main.cpp
@@ -17,56 +17,19 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include "mbed-trace/mbed_trace.h"
 #include "mbedtls/entropy_poll.h"
 
 #include "security.h"
 
 #include "mbed.h"
-#include "rtos.h"
 
-#if MBED_CONF_APP_NETWORK_INTERFACE == WIFI
-    #if TARGET_UBLOX_EVK_ODIN_W2
-        #include "OdinWiFiInterface.h"
-        OdinWiFiInterface wifi;
-	#else
-		#include "ESP8266Interface.h"
-		ESP8266Interface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
-    #endif
-#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
-    #include "EthernetInterface.h"
-    EthernetInterface eth;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
-    #define MESH
-    #include "NanostackInterface.h"
-    LoWPANNDInterface mesh;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
-    #define MESH
-    #include "NanostackInterface.h"
-    ThreadInterface mesh;
-#endif
-
-#if defined(MESH)
-#if MBED_CONF_APP_MESH_RADIO_TYPE == ATMEL
-#include "NanostackRfPhyAtmel.h"
-NanostackRfPhyAtmel rf_phy(ATMEL_SPI_MOSI, ATMEL_SPI_MISO, ATMEL_SPI_SCLK, ATMEL_SPI_CS,
-                           ATMEL_SPI_RST, ATMEL_SPI_SLP, ATMEL_SPI_IRQ, ATMEL_I2C_SDA, ATMEL_I2C_SCL);
-#elif MBED_CONF_APP_MESH_RADIO_TYPE == MCR20
-#include "NanostackRfPhyMcr20a.h"
-NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, MCR20A_SPI_CS, MCR20A_SPI_RST, MCR20A_SPI_IRQ);
-#endif //MBED_CONF_APP_RADIO_TYPE
-#endif //MESH
-
-#ifdef MESH
-    // Mesh does not have DNS, so must use direct IPV6 address
-    #define MBED_SERVER_ADDRESS "coaps://[2607:f0d0:2601:52::20]:5684"
-#else
-    // This is address to mbed Device Connector, name based
-    // assume all other stacks support DNS properly
-    #define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
-#endif
-
-RawSerial output(USBTX, USBRX);
+// easy-connect compliancy, it has 2 sets of wifi pins we have only one
+#define MBED_CONF_APP_ESP8266_TX MBED_CONF_APP_WIFI_TX
+#define MBED_CONF_APP_ESP8266_RX MBED_CONF_APP_WIFI_RX
+#include "easy-connect/easy-connect.h"
 
 // Status indication
 DigitalOut red_led(LED1);
@@ -176,7 +139,7 @@ public:
         // turn the buffer into a string, and initialize a vector<int> on the heap
         std::string s((char*)buffIn, sizeIn);
         free(buffIn);
-        output.printf("led_execute_callback pattern=%s\r\n", s.c_str());
+        printf("led_execute_callback pattern=%s\n", s.c_str());
 
         // our pattern is something like 500:200:500, so parse that
         std::size_t found = s.find_first_of(":");
@@ -196,11 +159,11 @@ public:
             String resource_name = param->get_argument_resource_name();
             int payload_length = param->get_argument_value_length();
             uint8_t* payload = param->get_argument_value();
-            output.printf("Resource: %s/%d/%s executed\r\n", object_name.c_str(), object_instance_id, resource_name.c_str());
-            output.printf("Payload: %.*s\r\n", payload_length, payload);
+            printf("Resource: %s/%d/%s executed\n", object_name.c_str(), object_instance_id, resource_name.c_str());
+            printf("Payload: %.*s\n", payload_length, payload);
         }
         // do_blink is called with the vector, and starting at -1
-        blinky_thread.start(this, &LedResource::do_blink);
+        blinky_thread.start(callback(this, &LedResource::do_blink));
     }
 
 private:
@@ -266,9 +229,9 @@ public:
         // up counter
         counter++;
 #ifdef TARGET_K64F
-        printf("handle_button_click, new value of counter is %d\r\n", counter);
+        printf("handle_button_click, new value of counter is %d\n", counter);
 #else
-        printf("simulate button_click, new value of counter is %d\r\n", counter);
+        printf("simulate button_click, new value of counter is %d\n", counter);
 #endif
         // serialize the value of counter as a string, and tell connector
         char buffer[20];
@@ -304,9 +267,9 @@ public:
         if (argument) {
             if (M2MBlockMessage::ErrorNone == argument->error_code()) {
                 if (argument->is_last_block()) {
-                    output.printf("Last block received\r\n");
+                    printf("Last block received\n");
                 }
-                output.printf("Block number: %d\r\n", argument->block_number());
+                printf("Block number: %d\n", argument->block_number());
                 // First block received
                 if (argument->block_number() == 0) {
                     // Store block
@@ -315,14 +278,14 @@ public:
                     // Store blocks
                 }
             } else {
-                output.printf("Error when receiving block message!  - EntityTooLarge\r\n");
+                printf("Error when receiving block message!  - EntityTooLarge\n");
             }
-            output.printf("Total message size: %d\r\n", argument->total_message_size());
+            printf("Total message size: %" PRIu32 "\n", argument->total_message_size());
         }
     }
 
     void block_message_requested(const String& resource, uint8_t *&/*data*/, uint32_t &/*len*/) {
-        output.printf("GET request received for resource: %s\r\n", resource.c_str());
+        printf("GET request received for resource: %s\n", resource.c_str());
         // Copy data and length to coap response
     }
 
@@ -344,11 +307,6 @@ void unregister() {
 void button_clicked() {
     clicked = true;
     updates.release();
-}
-
-// debug printf function
-void trace_printer(const char* str) {
-    printf("%s\r\n", str);
 }
 
 // Entry point to the program
@@ -378,51 +336,24 @@ Add MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES and MBEDTLS_TEST_NULL_ENTROPY in mbed_app
     srand(seed);
     red_led = 1;
     blue_led = 1;
+
     status_ticker.attach_us(blinky, 250000);
     // Keep track of the main thread
     mainThread = osThreadGetId();
 
-    // Sets the console baud-rate
-    output.baud(115200);
-
-    output.printf("\r\nStarting mbed Client example in ");
+    printf("\nStarting mbed Client example in ");
 #if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
-    output.printf("IPv6 mode\r\n");
+    printf("IPv6 mode\n");
 #else
-    output.printf("IPv4 mode\r\n");
+    printf("IPv4 mode\n");
 #endif
 
     mbed_trace_init();
-    mbed_trace_print_function_set(trace_printer);
 
-    NetworkInterface *network_interface = 0;
-    int connect_success = -1;
-#if MBED_CONF_APP_NETWORK_INTERFACE == WIFI
-    output.printf("\n\rConnecting to WiFi...\r\n");
-    connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
-    network_interface = &wifi;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
-    output.printf("\n\rConnecting to ethernet...\r\n");
-    connect_success = eth.connect();
-    network_interface = &eth;
-#endif
-#ifdef MESH
-    output.printf("\n\rConnecting to Mesh...\r\n");
-    mesh.initialize(&rf_phy);
-    connect_success = mesh.connect();
-    network_interface = &mesh;
-#endif
-    if(connect_success == 0) {
-    output.printf("\n\rConnected to Network successfully\r\n");
-    } else {
-        output.printf("\n\rConnection to Network Failed %d! Exiting application....\r\n", connect_success);
-        return 0;
-    }
-    const char *ip_addr = network_interface->get_ip_address();
-    if (ip_addr) {
-        output.printf("IP address %s\r\n", ip_addr);
-    } else {
-        output.printf("No IP address\r\n");
+    NetworkInterface* network = easy_connect(true);
+    if(network == NULL) {
+        printf("\nConnection to Network Failed - exiting application...\n");
+        return -1;
     }
 
     // we create our button and LED resources
@@ -444,7 +375,7 @@ Add MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES and MBEDTLS_TEST_NULL_ENTROPY in mbed_app
 #endif
 
     // Create endpoint interface to manage register and unregister
-    mbed_client.create_interface(MBED_SERVER_ADDRESS, network_interface);
+    mbed_client.create_interface(MBED_SERVER_ADDRESS, network);
 
     // Create Objects of varying types, see simpleclient.h for more details on implementation.
     M2MSecurity* register_object = mbed_client.create_register_object(); // server object specifying connector info

--- a/main.cpp
+++ b/main.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include "simpleclient.h"
 #include <string>
 #include <sstream>
 #include <vector>
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
 #include "mbed-trace/mbed_trace.h"
 #include "mbedtls/entropy_poll.h"
 

--- a/mcr20a-rf-driver.lib
+++ b/mcr20a-rf-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mcr20a-rf-driver/#d8810e105d7d35315aa708ec51d821156cad45e9


### PR DESCRIPTION
Integrate easy-connect
- we can remove all the external RF-drivers from main folder
- get easy-connect into use
- remove all the complicated network stuff

Fix serial - we don't need raw serial and we don't need to initialize it
if we set the right stuff to mbed_app.json (added). Plain printf() works
and it even does type checking now. (Points to Kevin Bracey on this).

Start the thread in a non-deprecated way using callback to remove one compiler
warning (again, points to Kevin Bracey).