### PR TITLE
Add links to hardware table from mesh-minimal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The application:
  * K64F + GROVE SEEED shield (Wifi)
  * NUCLEO_F429ZI + GROVE SEEED shield (Wifi)
 
-Apart from this, this example can work on other mbed OS supported hardware boards which support any of the given network interface including Ethernet, WiFi, Mesh (6LoWPAN) or Thread, provided the configuration fulfills condition that the target hardware has TLS entropy implemented for it and the complete example configuration of mbed Client, selected network interface and mbed OS components fits into hardware's given memory size (Flash size and RAM size). 
+Apart from this, this example can work on other mbed OS supported hardware boards which support any of the given network interface including Ethernet, WiFi, Mesh (6LoWPAN) or Thread, provided the configuration fulfills condition that the target hardware has TLS entropy implemented for it and the complete example configuration of mbed Client, selected network interface and mbed OS components fits into hardware's given memory size (Flash size and RAM size). See Mesh-minimal's [Notes on different hardware](https://github.com/ARMmbed/mbed-os-example-mesh-minimal/blob/master/Hardware.md) for known combinations of development boards and RF shields that have been tested with mesh networking stack.
 
 To see how different targets are built please see the supplied `build_all.sh script`.
 


### PR DESCRIPTION
In this table, we will collect information of shields that have been working, or ones that clearly do not work.
It is a good idea to point to that table here, even that HWs are directly specified in the README.
