### PR TITLE
Remove LWIP config from wifi_esp8266_v4.json

### DIFF
--- a/configs/wifi_esp8266_v4.json
+++ b/configs/wifi_esp8266_v4.json
@@ -24,11 +24,9 @@
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
     "target_overrides": {
         "*": {
-            "target.features_add": ["LWIP", "COMMON_PAL"],
+            "target.features_add": ["COMMON_PAL"],
             "platform.stdio-baud-rate": 115200,
             "platform.stdio-convert-newlines": true,
-            "lwip.ipv4-enabled": true,
-            "lwip.ipv6-enabled": false,
             "mbed-trace.enable": 0
         },
         "NUCLEO_F401RE": {


### PR DESCRIPTION
## Status
**READY**

## Description
The ESP8266 module has a built-in IP stack, therefore LWIP should be removed from the json config.
Also, need to remove the `lwip.ipv?-enabled` options.
Tested on K64 and NUCLEO_F429 and works fine.

## Todos
- [x] Tests
- [ ] Documentation



