### PR TITLE
Fix issue 237

### DIFF
--- a/configs/eth_v4.json
+++ b/configs/eth_v4.json
@@ -8,7 +8,7 @@
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
     "target_overrides": {
         "*": {
-            "target.features_add": ["LWIP", "COMMON_PAL"],
+            "target.features_add": ["LWIP", "NANOSTACK", "COMMON_PAL"],
             "platform.stdio-baud-rate": 115200,
             "platform.stdio-convert-newlines": true,
             "lwip.ipv4-enabled": true,


### PR DESCRIPTION
It seems like NANOSTACK is required to avoid a build error.

## Status
**READY**

## Migrations
NO

## Description
Fix [issue 237](https://github.com/ARMmbed/mbed-os-example-client/issues/237)

