### PR TITLE
Update mbed OS to 5.4.6

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8d21974ba35e04c4854e5090c0f8283171664175
+https://github.com/ARMmbed/mbed-os/#5fff7e1daeb395aa3d1ecf3f9ec3f4fead3de0c2


### PR DESCRIPTION
Updating mbed-os to mbed-os-5.4.6.
Original pull req from Anna Bridge in; https://github.com/ARMmbed/mbed-os-example-client/pull/250
