### PR TITLE
easy-connect / ESP8266 - gethostbyname

### DIFF
--- a/easy-connect.lib
+++ b/easy-connect.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/easy-connect/#7422ed0676155435a30851e6ffd6c75660a6577e
+https://github.com/ARMmbed/easy-connect/#144eecae16af07c4c5a37640dff98de323f7eba1


### PR DESCRIPTION
Resolve ESP8266 DNS query failure with names >63 characters.
