### PR TITLE
Enabling SiLabs ThunderBoard Sense 2

### DIFF
--- a/configs/mesh_thread.json
+++ b/configs/mesh_thread.json
@@ -5,7 +5,7 @@
             "value": "MESH_THREAD"
         },
         "mesh_radio_type": {
-        	"help": "options are ATMEL, MCR20",
+        	"help": "options are ATMEL, MCR20, EFR32",
         	"value": "ATMEL"
         }
     },

--- a/easy-connect.lib
+++ b/easy-connect.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/easy-connect/#7422ed0676155435a30851e6ffd6c75660a6577e
+https://github.com/ARMmbed/easy-connect/#211cdf2bfa33387ce3efe0299aa126788cd98cf5

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -5,8 +5,8 @@
             "value": "ETHERNET"
         },
         "mesh_radio_type": {
-        	"help": "options are ATMEL, MCR20, SPIRIT1",
-        	"value": "ATMEL"
+        	"help": "options are ATMEL, MCR20, SPIRIT1, EFR32",
+        	"value": "EFR32"
         },
         "wifi-ssid": {
             "help": "WiFi SSID",

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -6,7 +6,7 @@
         },
         "mesh_radio_type": {
         	"help": "options are ATMEL, MCR20, SPIRIT1, EFR32",
-        	"value": "EFR32"
+        	"value": "ATMEL"
         },
         "wifi-ssid": {
             "help": "WiFi SSID",

--- a/simpleclient.h
+++ b/simpleclient.h
@@ -36,6 +36,7 @@
 #define ATMEL           5
 #define MCR20           6
 #define SPIRIT1         7
+#define EFR32           8
 
 #define STRINGIFY(s) #s
 


### PR DESCRIPTION
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).

## Status
**READY**

## Migrations
NO

## Description
Enabling SiLabs Thunderboard Sense 2 with mbed Client.

## Related PRs
https://github.com/ARMmbed/easy-connect/pull/35

branch | PR
------ | ------
easy-connect | [https://github.com/ARMmbed/easy-connect/pull/35]()

## Todos
- [x] Tests
- [ ] Documentation

## Deploy Notes
Notes regarding deployment the contained body of work.

## Steps to Test or Reproduce
Build mbed-os-example-client for "TB_SENSE_12" target with THREAD_ROUTER and appropriate Thread channel number,PAN ID etc as that of border router, select EFR32 in mbed_app.json for radio. Flash binary to target. It should connect to mesh network of BR and register with mDC.
security.h is also required from your personal mDC account.

Successful run output screenshot attached below:

![tb_sense_12_mdc_ok_withcomments](https://user-images.githubusercontent.com/17567812/28629453-62bcec06-721f-11e7-85f5-4106746497f3.jpg)


## Impacted Areas in Application
List components, applications or use-cases that this PR will affect:

* easy-connect : Lib updated with latest version further to approval and merger of https://github.com/ARMmbed/easy-connect/pull/35 
