### PR TITLE
IOTCLT-1737: use abstracted button names

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -11,6 +11,7 @@ mbed compile -m K64F -t $TOOL
 cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-eth-v4.bin
 mbed compile -m NUCLEO_F429ZI -t $TOOL
 cp ./BUILD/NUCLEO_F429ZI/$TOOL/mbed-os-example-client.bin f429zi-$TOOL-eth-v4.bin
+cp configs/eth_odin_v4.json ./mbed_app.json
 mbed compile -m UBLOX_EVK_ODIN_W2 -t $TOOL
 cp ./BUILD/UBLOX_EVK_ODIN_W2/$TOOL/mbed-os-example-client.bin ublox-odin-$TOOL-eth-v4.bin
 
@@ -21,6 +22,7 @@ mbed compile -m K64F -t $TOOL
 cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-eth-v6.bin
 mbed compile -m NUCLEO_F429ZI -t $TOOL
 cp ./BUILD/NUCLEO_F429ZI/$TOOL/mbed-os-example-client.bin f429zi-$TOOL-eth-v4.bin
+cp configs/eth_odin_v6.json ./mbed_app.json
 mbed compile -m UBLOX_EVK_ODIN_W2 -t $TOOL
 cp ./BUILD/UBLOX_EVK_ODIN_W2/$TOOL/mbed-os-example-client.bin ublox-odin-$TOOL-eth-v6.bin
 

--- a/configs/eth_odin_v4.json
+++ b/configs/eth_odin_v4.json
@@ -3,10 +3,6 @@
         "network-interface":{
             "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
             "value": "ETHERNET"
-        },
-        "button1": {
-        	"help": "Use BUTTON1 from PinNames.h by default",
-        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],

--- a/configs/eth_odin_v6.json
+++ b/configs/eth_odin_v6.json
@@ -3,10 +3,6 @@
         "network-interface":{
             "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
             "value": "ETHERNET"
-        },
-        "button1": {
-        	"help": "Use BUTTON1 from PinNames.h by default",
-        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
@@ -15,8 +11,8 @@
             "target.features_add": ["LWIP", "COMMON_PAL"],
             "platform.stdio-baud-rate": 115200,
             "platform.stdio-convert-newlines": true,
-            "lwip.ipv4-enabled": true,
-            "lwip.ipv6-enabled": false,
+            "lwip.ipv4-enabled": false,
+            "lwip.ipv6-enabled": true,
             "mbed-trace.enable": 0
         },
             "UBLOX_EVK_ODIN_W2": {

--- a/configs/eth_v6.json
+++ b/configs/eth_v6.json
@@ -3,6 +3,10 @@
         "network-interface":{
             "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
             "value": "ETHERNET"
+        },
+        "button1": {
+        	"help": "Use BUTTON1 from PinNames.h by default",
+        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],

--- a/configs/mesh_6lowpan.json
+++ b/configs/mesh_6lowpan.json
@@ -7,6 +7,10 @@
         "mesh_radio_type": {
         	"help": "options are ATMEL, MCR20",
         	"value": "ATMEL"
+        },
+        "button1": {
+        	"help": "Use BUTTON1 from PinNames.h by default",
+        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],

--- a/configs/mesh_6lowpan_subg.json
+++ b/configs/mesh_6lowpan_subg.json
@@ -7,6 +7,10 @@
         "mesh_radio_type": {
         	"help": "options are ATMEL, MCR20, SPIRIT1",
         	"value": "SPIRIT1"
+        },
+        "button1": {
+        	"help": "Use BUTTON1 from PinNames.h by default",
+        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],

--- a/configs/mesh_thread.json
+++ b/configs/mesh_thread.json
@@ -7,6 +7,10 @@
         "mesh_radio_type": {
         	"help": "options are ATMEL, MCR20, EFR32",
         	"value": "ATMEL"
+        },
+        "button1": {
+        	"help": "Use BUTTON1 from PinNames.h by default",
+        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],

--- a/configs/wifi_esp8266_v4.json
+++ b/configs/wifi_esp8266_v4.json
@@ -19,6 +19,10 @@
         "wifi-rx": {
             "help": "RX pin for serial connection to external device",
             "value": "D0"
+        },
+        "button1": {
+        	"help": "Use BUTTON1 from PinNames.h by default",
+        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],

--- a/configs/wifi_odin_v4.json
+++ b/configs/wifi_odin_v4.json
@@ -19,6 +19,10 @@
         "wifi-rx": {
             "help": "RX pin for serial connection to external device",
             "value": "D0"
+        },
+        "button1": {
+        	"help": "Use BUTTON1 from PinNames.h by default",
+        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],

--- a/main.cpp
+++ b/main.cpp
@@ -292,11 +292,7 @@ public:
 
             // up counter
             counter++;
-    #ifdef TARGET_K64F
             printf("handle_button_click, new value of counter is %d\n", counter);
-    #else
-            printf("simulate button_click, new value of counter is %d\n", counter);
-    #endif
             // serialize the value of counter as a string, and tell connector
             char buffer[20];
             int size = sprintf(buffer,"%d",counter);

--- a/main.cpp
+++ b/main.cpp
@@ -78,12 +78,15 @@ MbedClient mbed_client(device);
  * for regular updates for the resources.
  *
  * MBED_CONF_APP_BUTTON1 is mapped to actual button pin the mbed_app.json file, where you need to
- * specify board-specific values or leave them undefined if the board does not have buttons.
+ * specify board-specific value or leave it undefined if the board does not have buttons.
  */
 class InteractionProvider {
 
 public:
 	InteractionProvider(Semaphore& updates_sem) : updates(updates_sem) {
+
+	    timer_ticked = false;
+	    clicked = false;
 
 		// Set up handler function for the interaction button, if available
 
@@ -97,8 +100,8 @@ public:
 	}
 
 	// flags for interaction, these are read from outside interrupt context
-	volatile bool timer_ticked = false;
-	volatile bool clicked = false;
+	volatile bool timer_ticked;
+	volatile bool clicked;
 
 
 private:

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -23,6 +23,10 @@
         "wifi-rx": {
             "help": "RX pin for serial connection to external device",
             "value": "D0"
+        },
+        "button1": {
+        	"help": "Use BUTTON1 from PinNames.h by default",
+        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -23,10 +23,6 @@
         "wifi-rx": {
             "help": "RX pin for serial connection to external device",
             "value": "D0"
-        },
-        "button1": {
-        	"help": "Use BUTTON1 from PinNames.h by default",
-        	"value": "BUTTON1"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],


### PR DESCRIPTION
## Status
**NOT READY**

## Migrations
NO

## Description
Use abstracted button names and forget K64F-specific code. Refactored interaction functionality and ticker code to a separate class. Marked as not ready since this is just one possible approach to the issue and could be unnecessary.

## Related PR
https://github.com/ARMmbed/mbed-os-example-client/pull/289
