### PR TITLE
Easy-connect - driver updates, mesh fix

### DIFF
--- a/easy-connect.lib
+++ b/easy-connect.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/easy-connect/#211cdf2bfa33387ce3efe0299aa126788cd98cf5
+https://github.com/ARMmbed/easy-connect/#15b79c8657b87f13da52dee8d41b3cbea4f7e2f0


### PR DESCRIPTION
Almost all drivers updated since previous update:
- esp8266
- Spirit1
- Atmel RF
- MCR20A

Also fixes the mesh network board selection, it was faulty as well (this fix is critical for mesh user).
- see https://github.com/ARMmbed/easy-connect/pull/40 for details.
