### PR TITLE
Added CELLULAR as an interface option.

### DIFF
--- a/configs/cellular_c030_u201.json
+++ b/configs/cellular_c030_u201.json
@@ -1,0 +1,23 @@
+{
+    "config": {
+        "network-interface":{
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
+            "value": "CELLULAR_ONBOARD"
+        },
+    },
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
+    "target_overrides": {
+        "*": {
+            "target.features_add": ["LWIP", "COMMON_PAL"],
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines":true,
+            "lwip.ipv4-enabled": true,
+            "lwip.ipv6-enabled": false,
+            "mbed-trace.enable": 0
+        },
+        "UBLOX_C030_U201": {
+            "lwip.ppp-enabled": true,
+            "ppp-cell-iface.apn-lookup": true
+        }
+    }
+}

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,12 +1,12 @@
 {
     "config": {
         "network-interface":{
-            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
             "value": "ETHERNET"
         },
         "mesh_radio_type": {
-        	"help": "options are ATMEL, MCR20, SPIRIT1, EFR32",
-        	"value": "ATMEL"
+            "help": "options are ATMEL, MCR20, SPIRIT1, EFR32",
+            "value": "ATMEL"
         },
         "wifi-ssid": {
             "help": "WiFi SSID",
@@ -44,7 +44,11 @@
             "wifi-rx": "PA_12"
         },
         "UBLOX_EVK_ODIN_W2": {
-        "target.device_has_remove": ["EMAC"]
+            "target.device_has_remove": ["EMAC"]
+        },
+        "UBLOX_C030_U201": {
+            "lwip.ppp-enabled": true,
+            "ppp-cell-iface.apn-lookup": true
         }
     }
 }


### PR DESCRIPTION
Add necessary configuration items to support a `UBLOX_C030_U201` board with the new standard mbed-os PPP Cellular interface.  See also PR [ARMmbed/easy-connect #41](https://github.com/ARMmbed/easy-connect/pull/41).