### PR TITLE
Realtek RTL8195AM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ With Thread, you can change the operating mode of the client from the default ro
 * K64F + GROVE SEEED shield using [ESP8266](https://en.wikipedia.org/wiki/ESP8266) WiFi module.
 * NUCLEO_F429ZI + GROVE SEEED shield using [ESP8266](https://en.wikipedia.org/wiki/ESP8266) WiFi module.
 * [NUCLEO_F401RE](https://os.mbed.com/platforms/ST-Nucleo-F401RE/) + [X-NUCLEO-IDW0XX1](https://github.com/ARMmbed/wifi-x-nucleo-idw01m1/).
+* [REALTEK_RTL8195AM](https://developer.mbed.org/platforms/REALTEK-RTL8195AM/) + in-built WiFi. Please update the [DAPLINK]((https://developer.mbed.org/platforms/REALTEK-RTL8195AM/#daplink-firmware-update).) 1st.
 
 To run this application using ESP8266 WiFi Interface, you need:
 
@@ -167,7 +168,7 @@ To run this application using ESP8266 WiFi Interface, you need:
 
 ```json
     "network-interface": {
-        "help": "options are ETHERNET,WIFI_ESP8266,WIFI_IDW0XX1,WIFI_ODIN,MESH_LOWPAN_ND,MESH_THREAD.",
+        "help": "options are ETHERNET, WIFI_ESP8266, WIFI_IDW0XX1, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND,MESH_THREAD.",
         "value": "WIFI_ESP8266"
     }
 ```
@@ -231,6 +232,16 @@ cp configs/mesh-mbedignore ./.mbedignore
 ```
 
 If you have issues with the `X-NUCLEO-IDW04A1` board, please double-check that macro `IDW04A1_WIFI_HW_BUG_WA` has been added to the `macros` section of the `mbed_app.json` file.
+
+#### Compile configuration for REALTEK_RTL8195AM (aka Realtek Ameba) board
+
+Use the supplied `configs/wifi_rtw_v4.json` file as the basis.
+
+``` bash
+cp configs/wifi_rtw_v4.json mbed_app.json
+<use your favourite editor to modify mbed_app.json for WiFi SSUD/Password>
+mbed compile -m REALTEK_RTL8195AM -t <your_toolchain>
+```
 
 ### Non listed board support 
 
@@ -410,9 +421,20 @@ To learn how to get notifications when resource 1 changes, or how to use resourc
 
 ## Known issues
 
-### Mbed OS 5.4
+1. Mutex issue using debug profile, issue #[303](https://github.com/ARMmbed/mbed-os-example-client/issues/303).
 
-* [UBLOX_EVK_ODIN_W2]: This example is not compiling with IAR. See [#194](https://github.com/ARMmbed/mbed-os-example-client/issues/194)
-* [NUCLEO_F429ZI]: This example is not compiling with IAR. See [#194](https://github.com/ARMmbed/mbed-os-example-client/issues/194)
+### REALTEK_RTL8195AM
 
-Fix for those issues coming via; [mbed-os PR 3920] (https://github.com/ARMmbed/mbed-os/pull/3920)
+Realtek RTL8195AM board does not have any LEDs that would be connected to the main MCU. The existing LEDs are all connected to the DAPLINK host processor. So, in order to get the LEDs working one has to connect an external LED, instead. The LED needs to be connected to GPIOB_4 and GND, please see pinout in [Realtek RTL8195AM-page](https://os.mbed.com/platforms/Realtek-RTL8195AM/#rtl8195am-pinout-right).
+
+The board does not have any buttons connected to the main MCU either, so that is why the button is mapped to `NC` (Not Connected) in the `wifi_rtw_v4.json`.
+
+Secondly, at least for now, this board is not fully without issues. The following issues have been raised in Mbed OS repository - please follow those for fixes.
+
+1. ISR overflow issues with this example - Mbed OS #[5640](https://github.com/ARMmbed/mbed-os/issues/5640).
+1. Compilation issues with on-line compiler - Mbed OS #[5626](https://github.com/ARMmbed/mbed-os/issues/5626).
+1. Stability issues - Mbed OS #[5056](https://github.com/ARMmbed/mbed-os/issues/5056).
+1. UVision support not complete - Mbed OS #[4651](https://github.com/ARMmbed/mbed-os/issues/4651).
+1. DAPLINK in REALTEK-RTL8195AM is a bit old - Mbed OS #[5643](https://github.com/ARMmbed/mbed-os/issues/5643).
+
+All of these issues are being worked on and fixes will come in, so please follow-up the related items.

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ Use the supplied `configs/wifi_rtw_v4.json` file as the basis.
 
 ``` bash
 cp configs/wifi_rtw_v4.json mbed_app.json
-<use your favourite editor to modify mbed_app.json for WiFi SSUD/Password>
-mbed compile -m REALTEK_RTL8195AM -t <your_toolchain>
+<use your favourite editor to modify mbed_app.json for WiFi SSID/Password>
+mbed compile -m REALTEK_RTL8195AM -t <TOOLCHAIN>
 ```
 
 ### Non listed board support 

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash  
+#!/bin/bash
 #
 set -e
 TOOL=GCC_ARM
@@ -7,64 +7,92 @@ echo Compiling with $TOOL
 echo Ethernet v4
 cp configs/eth_v4.json ./mbed_app.json
 cp configs/eth-wifi-mbedignore ./.mbedignore
-mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-eth-v4.bin
-mbed compile -m NUCLEO_F429ZI -t $TOOL
-cp ./BUILD/NUCLEO_F429ZI/$TOOL/mbed-os-example-client.bin f429zi-$TOOL-eth-v4.bin
+BOARD=K64F
+mbed compile -m $BOARD -t $TOOL
+cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v4.bin
+
+BOARD=NUCLEO_F429ZI
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v4.bin
 cp configs/eth_odin_v4.json ./mbed_app.json
-mbed compile -m UBLOX_EVK_ODIN_W2 -t $TOOL
-cp ./BUILD/UBLOX_EVK_ODIN_W2/$TOOL/mbed-os-example-client.bin ublox-odin-$TOOL-eth-v4.bin
+
+BOARD=UBLOX_EVK_ODIN_W2
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v4.bin
 
 echo Ethernet v6
 cp configs/eth_v6.json ./mbed_app.json
 cp configs/eth-wifi-mbedignore ./.mbedignore
-mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-eth-v6.bin
-mbed compile -m NUCLEO_F429ZI -t $TOOL
-cp ./BUILD/NUCLEO_F429ZI/$TOOL/mbed-os-example-client.bin f429zi-$TOOL-eth-v4.bin
+
+BOARD=K64F
+mbed compile -m $BOARD -t $TOOL
+cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v6.bin
+
+BOARD=NUCLEO_F429ZI
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v4.bin
+
+BOARD=UBLOX_EVK_ODIN_W2
 cp configs/eth_odin_v6.json ./mbed_app.json
-mbed compile -m UBLOX_EVK_ODIN_W2 -t $TOOL
-cp ./BUILD/UBLOX_EVK_ODIN_W2/$TOOL/mbed-os-example-client.bin ublox-odin-$TOOL-eth-v6.bin
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v6.bin
 
 echo WIFI - ESP8266 
 cp configs/wifi_esp8266_v4.json ./mbed_app.json
 cp configs/eth-wifi-mbedignore ./.mbedignore
-mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-esp-wifi-v4.bin
-mbed compile -m NUCLEO_F429ZI -t $TOOL
-cp ./BUILD/NUCLEO_F429ZI/$TOOL/mbed-os-example-client.bin f429zi-$TOOL-esp-wifi-v4.bin
+BOARD=K64F
+mbed compile -m $BOARD -t $TOOL
+cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-esp-wifi-v4.bin
+
+BOARD=NUCLEO_F429ZI
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-esp-wifi-v4.bin
 
 echo WIFI - ODIN for UBLOX_EVK_ODIN_W2
 cp configs/wifi_odin_v4.json ./mbed_app.json
 cp configs/eth-wifi-mbedignore ./.mbedignore
-mbed compile -m UBLOX_EVK_ODIN_W2 -t $TOOL
-cp ./BUILD/UBLOX_EVK_ODIN_W2/$TOOL/mbed-os-example-client.bin ublox-odin-$TOOL-wifi-v4.bin
+BOARD=UBLOX_EVK_ODIN_W2
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-wifi-v4.bin
 
 echo 6-Lowpan builds
 cp configs/mesh_6lowpan.json ./mbed_app.json
 cp configs/mesh-mbedignore ./.mbedignore
-mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-6lowpan.bin
-mbed compile -m NUCLEO_F429ZI -t $TOOL
-cp ./BUILD/NUCLEO_F429ZI/$TOOL/mbed-os-example-client.bin f429zi-$TOOL-6lowpan.bin
+BOARD=K64F
+mbed compile -m $BOARD -t $TOOL
+cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-6lowpan.bin
+
+BOARD=NUCLEO_F429ZI
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-6lowpan.bin
 
 echo 6-Lowpan Sub-1 GHz builds
 cp configs/mesh_6lowpan_subg.json ./mbed_app.json
 cp configs/mesh-mbedignore ./.mbedignore
-mbed compile -m NUCLEO_F429ZI -t $TOOL
-cp ./BUILD/NUCLEO_F429ZI/$TOOL/mbed-os-example-client.bin f429zi-$TOOL-6lowpan-subg.bin
+BOARD=NUCLEO_F429ZI
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-6lowpan-subg.bin
 
 echo Thread builds
 cp configs/mesh_thread.json ./mbed_app.json
 cp configs/mesh-mbedignore ./.mbedignore
-mbed compile -m K64F -t $TOOL
-cp BUILD/K64F/$TOOL/mbed-os-example-client.bin k64f-$TOOL-Thread.bin
-mbed compile -m NUCLEO_F429ZI -t $TOOL
-cp ./BUILD/NUCLEO_F429ZI/$TOOL/mbed-os-example-client.bin f429zi-$TOOL-Thread.bin
+BOARD=K64F
+mbed compile -m $BOARD -t $TOOL
+cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-Thread.bin
+
+BOARD=NUCLEO_F429ZI
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-Thread.bin
 
 echo WiFi-X-Nucleo
 cp configs/wifi_idw01m1_v4.json mbed_app.json
-cp configs/wifi-idw0xx1-mbedignore .mbedignore
-mbed compile -m NUCLEO_F401RE -t $TOOL
-cp ./BUILD/NUCLEO_F401RE/GCC_ARM/mbed-os-example-client.bin f401re-$TOOL-WifiXNucleo.bin
+cp configs/eth-wifi-mbedignore ./.mbedignore
+BOARD=NUCLEO_F401RE
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-WifiXNucleo.bin
 
+echo Realtek RTL8195AM WiFi
+BOARD=REALTEK_RTL8195AM
+cp configs/wifi_rtw_v4.json mbed_app.json
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-Wifi.bin

--- a/configs/wifi_rtw_v4.json
+++ b/configs/wifi_rtw_v4.json
@@ -1,0 +1,38 @@
+{
+    "config": {
+        "network-interface":{
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD",
+            "value": "WIFI_RTW"
+        },
+        "wifi-ssid": {
+            "help": "WiFi SSID",
+            "value": "\"SSID\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"Password\""
+        },
+        "wifi-tx": {
+            "help": "TX pin for serial connection to external device",
+            "value": "D1"
+        },
+        "wifi-rx": {
+            "help": "RX pin for serial connection to external device",
+            "value": "D0"
+        },
+        "button1": {
+        	"help": "Use BUTTON1 from PinNames.h by default",
+        	"value": "NC"
+        }
+    },
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
+    "target_overrides": {
+        "*": {
+            "drivers.uart-serial-rxbuf-size": 1024,
+            "target.features_add": ["COMMON_PAL"],
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
+            "mbed-trace.enable": 0
+        }
+    }
+}


### PR DESCRIPTION
Support for compiling against Realtek RTL8195AM. Please note there
are some limitations:
- The board does not have any LEDs connected to the main cpu, therefore
  LED blinking will not work unless you connect an external LED.
- Buttons are not connected either.
- The client will crash after a while with
  CMSIS-RTOS error: ISR Queue overflow (status: 0x2, task ID: 0x0, object ID: 0x3006146C)
  issue has been raised to Mbed OS on this.
Issues are documented in the README.md changes.

## Status
**READY**

## Migrations
NO
