### PR TITLE
REALTEK_RTL8195AM - remove Wifi TX/RX-pin

### DIFF
--- a/configs/wifi_rtw_v4.json
+++ b/configs/wifi_rtw_v4.json
@@ -12,14 +12,6 @@
             "help": "WiFi Password",
             "value": "\"Password\""
         },
-        "wifi-tx": {
-            "help": "TX pin for serial connection to external device",
-            "value": "D1"
-        },
-        "wifi-rx": {
-            "help": "RX pin for serial connection to external device",
-            "value": "D0"
-        },
         "button1": {
         	"help": "Use BUTTON1 from PinNames.h by default",
         	"value": "NC"


### PR DESCRIPTION
As those are not needed at all with the Realtek - it's  a inbuilt Wifi on that board, so it's pins are hard-coded (as is the HW).
