### PR TITLE
IOTCLT-2328: Fix include ordering

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,6 @@
  */
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
-#include "simpleclient.h"
 #include <string>
 #include <sstream>
 #include <vector>
@@ -30,6 +29,9 @@
 #define MBED_CONF_APP_ESP8266_TX MBED_CONF_APP_WIFI_TX
 #define MBED_CONF_APP_ESP8266_RX MBED_CONF_APP_WIFI_RX
 #include "easy-connect/easy-connect.h"
+
+// Should be defined after easy-connect.h
+#include "simpleclient.h"
 
 #ifdef TARGET_STM
 #define RED_LED (LED3)


### PR DESCRIPTION
Fixed wrong ordering. Now Mesh connects in correct mode. Fixes #371 

[EasyConnect] Connected to Network successfully
SOCKET_MODE : UDP
Connecting to coaps://[2607:f0d0:2601:52::20]:5684