### PR TITLE
[RZ_A1H] Add config flag to desable TRNG/Emtropy

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -44,6 +44,9 @@
             "wifi-tx": "PA_11",
             "wifi-rx": "PA_12"
         },
+        "RZ_A1H": {
+            "target.macros_add": ["MBEDTLS_TEST_NULL_ENTROPY", "MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES"]
+        },
         "UBLOX_EVK_ODIN_W2": {
             "target.device_has_remove": ["EMAC"]
         },


### PR DESCRIPTION
I added the macro to disable TRNG/Entropy for GR-PEACH(RZ_A1H) because it doesn't support TRNG.


## Related PRs
https://github.com/ARMmbed/mbed-os/issues/5885