### PR TITLE
[STM] Add wifi ism43362 for DISCO_L475_IOT01A

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The corresponding Nanostack configuration option is:
 * K64F + GROVE SEEED shield using [ESP8266](https://en.wikipedia.org/wiki/ESP8266) WiFi module.
 * NUCLEO_F429ZI + GROVE SEEED shield using [ESP8266](https://en.wikipedia.org/wiki/ESP8266) WiFi module.
 * [NUCLEO_L476RG](https://os.mbed.com/platforms/ST-Nucleo-L476RG/) + [X-NUCLEO-IDW0XX1](https://github.com/ARMmbed/wifi-x-nucleo-idw01m1/).
+* [DISCO_L475VG_IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/) + ISM43362 built-in module
 * [REALTEK_RTL8195AM](https://developer.mbed.org/platforms/REALTEK-RTL8195AM/) + in-built WiFi. Please update the [DAPLINK]((https://developer.mbed.org/platforms/REALTEK-RTL8195AM/#daplink-firmware-update).) 1st.
 
 To run this application using ESP8266 WiFi Interface, you need:
@@ -225,6 +226,17 @@ Currently, two STM WiFi expansion boards are available:
 The label is clearly printed on the PCB.
 
 If you have issues with the `X-NUCLEO-IDW04A1` board, please double-check that macro `IDW04A1_WIFI_HW_BUG_WA` has been added to the `macros` section of the `mbed_app.json` file.
+
+#### Compile configuration for STM `DISCO_L475VG_IOT01A` platform
+
+Use the supplied `configs/wifi_ism43362.json` file as a basis.
+
+``` bash
+cp configs/wifi_ism43362.json mbed_app.json
+cp configs/wifi_ism43362-ignore .mbedignore
+<use your favourite editor to modify mbed_app.json for WiFi SSID/Password>
+mbed compile -m DISCO_L475VG_IOT01A -t <TOOLCHAIN>
+```
 
 #### Compile configuration for REALTEK_RTL8195AM (aka Realtek Ameba) board
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ Use the supplied `configs/wifi_ism43362.json` file as a basis.
 
 ``` bash
 cp configs/wifi_ism43362.json mbed_app.json
-cp configs/wifi_ism43362-ignore .mbedignore
 <use your favourite editor to modify mbed_app.json for WiFi SSID/Password>
 mbed compile -m DISCO_L475VG_IOT01A -t <TOOLCHAIN>
 ```

--- a/configs/wifi_ism43362.json
+++ b/configs/wifi_ism43362.json
@@ -1,0 +1,41 @@
+{
+    "config": {
+        "network-interface":{
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ISM43362, WIFI_ODIN, MESH_LOWPAN_ND, MESH_THREAD",
+            "value": "WIFI_ISM43362"
+        },
+        "wifi-ssid": {
+            "help": "WiFi SSID",
+            "value": "\"SSID\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"PASSWORD\""
+        },
+        "wifi-tx": {
+            "help": "TX pin for serial connection to external device",
+            "value": "D1"
+        },
+        "wifi-rx": {
+            "help": "RX pin for serial connection to external device",
+            "value": "D0"
+        }
+    },
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
+    "target_overrides": {
+        "*": {
+            "target.features_add": ["COMMON_PAL"],
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
+            "mbed-trace.enable": 0
+        },
+        "NUCLEO_F401RE": {
+            "wifi-tx": "PA_11",
+            "wifi-rx": "PA_12"
+        },
+        "NUCLEO_F411RE": {
+            "wifi-tx": "PA_11",
+            "wifi-rx": "PA_12"
+        }
+    }
+}

--- a/configs/wifi_ism43362_ignore
+++ b/configs/wifi_ism43362_ignore
@@ -1,0 +1,5 @@
+easy-connect/atmel-rf-driver/*
+easy-connect/mcr20a-rf-driver/*
+easy-connect/esp8266-driver/*
+easy-connect/stm-spirit1-rf-driver/*
+easy-connect/wifi-x-nucleo-idw01m1/*

--- a/configs/wifi_ism43362_ignore
+++ b/configs/wifi_ism43362_ignore
@@ -1,5 +1,0 @@
-easy-connect/atmel-rf-driver/*
-easy-connect/mcr20a-rf-driver/*
-easy-connect/esp8266-driver/*
-easy-connect/stm-spirit1-rf-driver/*
-easy-connect/wifi-x-nucleo-idw01m1/*


### PR DESCRIPTION
## Description
DISCO_L475VG_IOT01A and DISCO_F413ZH have an Inventek wifi module. This PR allows the DISCO_L475VG_IOT01A  to connect to the Device connector.
