### PR TITLE
build_all.sh - no mbedignore/one target fix

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -15,7 +15,6 @@ function patch_wifi {
 echo Compiling with $TOOL
 echo Ethernet v4
 cp configs/eth_v4.json ./mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 BOARD=K64F
 mbed compile -m $BOARD -t $TOOL
 cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v4.bin
@@ -31,7 +30,6 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v4.bin
 
 echo Ethernet v6
 cp configs/eth_v6.json ./mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 BOARD=K64F
 mbed compile -m $BOARD -t $TOOL
 cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v6.bin
@@ -47,7 +45,6 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v6.bin
 
 echo WIFI - ESP8266 
 cp configs/wifi_esp8266_v4.json ./mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 BOARD=K64F
 patch_wifi
 mbed compile -m $BOARD -t $TOOL
@@ -59,7 +56,6 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-esp-wifi-v4.bin
 
 echo WIFI - ODIN for UBLOX_EVK_ODIN_W2
 cp configs/wifi_odin_v4.json ./mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 patch_wifi
 BOARD=UBLOX_EVK_ODIN_W2
 mbed compile -m $BOARD -t $TOOL
@@ -67,7 +63,6 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-wifi-v4.bin
 
 echo 6-Lowpan builds
 cp configs/mesh_6lowpan.json ./mbed_app.json
-cp configs/mesh-mbedignore ./.mbedignore
 BOARD=K64F
 mbed compile -m $BOARD -t $TOOL
 cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-6lowpan.bin
@@ -78,14 +73,12 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-6lowpan.bin
 
 echo 6-Lowpan Sub-1 GHz builds
 cp configs/mesh_6lowpan_subg.json ./mbed_app.json
-cp configs/mesh-mbedignore ./.mbedignore
 BOARD=NUCLEO_F429ZI
 mbed compile -m $BOARD -t $TOOL
 cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-6lowpan-subg.bin
 
 echo Thread builds
 cp configs/mesh_thread.json ./mbed_app.json
-cp configs/mesh-mbedignore ./.mbedignore
 BOARD=K64F
 mbed compile -m $BOARD -t $TOOL
 cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-Thread.bin
@@ -96,15 +89,14 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-Thread.bin
 
 echo WiFi-X-Nucleo
 cp configs/wifi_idw01m1_v4.json mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 patch_wifi
-BOARD=NUCLEO_F401RE
+BOARD=NUCLEO_L476RG
 mbed compile -m $BOARD -t $TOOL
 cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-WifiXNucleo.bin
 
 echo Realtek RTL8195AM WiFi
 BOARD=REALTEK_RTL8195AM
-cp configs/wifi_rtw_v4.json mbed_app.json
 patch_wifi
 mbed compile -m $BOARD -t $TOOL
 cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-Wifi.bin
+


### PR DESCRIPTION
No need to copy the mbedignores anymore, so remove those lines.

Change the Nucleo F401RE to a Nucleo board that has TRNG and
entropy.
