### PR TITLE
Easy-connect update for ISM/Cellular & build_all fixes

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -15,7 +15,6 @@ function patch_wifi {
 echo Compiling with $TOOL
 echo Ethernet v4
 cp configs/eth_v4.json ./mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 BOARD=K64F
 mbed compile -m $BOARD -t $TOOL
 cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v4.bin
@@ -31,7 +30,6 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v4.bin
 
 echo Ethernet v6
 cp configs/eth_v6.json ./mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 BOARD=K64F
 mbed compile -m $BOARD -t $TOOL
 cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v6.bin
@@ -45,9 +43,8 @@ cp configs/eth_odin_v6.json ./mbed_app.json
 mbed compile -m $BOARD -t $TOOL
 cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-eth-v6.bin
 
-echo WIFI - ESP8266 
+echo WIFI - ESP8266
 cp configs/wifi_esp8266_v4.json ./mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 BOARD=K64F
 patch_wifi
 mbed compile -m $BOARD -t $TOOL
@@ -59,7 +56,6 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-esp-wifi-v4.bin
 
 echo WIFI - ODIN for UBLOX_EVK_ODIN_W2
 cp configs/wifi_odin_v4.json ./mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 patch_wifi
 BOARD=UBLOX_EVK_ODIN_W2
 mbed compile -m $BOARD -t $TOOL
@@ -67,7 +63,6 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-wifi-v4.bin
 
 echo 6-Lowpan builds
 cp configs/mesh_6lowpan.json ./mbed_app.json
-cp configs/mesh-mbedignore ./.mbedignore
 BOARD=K64F
 mbed compile -m $BOARD -t $TOOL
 cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-6lowpan.bin
@@ -78,14 +73,12 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-6lowpan.bin
 
 echo 6-Lowpan Sub-1 GHz builds
 cp configs/mesh_6lowpan_subg.json ./mbed_app.json
-cp configs/mesh-mbedignore ./.mbedignore
 BOARD=NUCLEO_F429ZI
 mbed compile -m $BOARD -t $TOOL
 cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-6lowpan-subg.bin
 
 echo Thread builds
 cp configs/mesh_thread.json ./mbed_app.json
-cp configs/mesh-mbedignore ./.mbedignore
 BOARD=K64F
 mbed compile -m $BOARD -t $TOOL
 cp BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-Thread.bin
@@ -96,9 +89,8 @@ cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-Thread.bin
 
 echo WiFi-X-Nucleo
 cp configs/wifi_idw01m1_v4.json mbed_app.json
-cp configs/eth-wifi-mbedignore ./.mbedignore
 patch_wifi
-BOARD=NUCLEO_F401RE
+BOARD=NUCLEO_L476RG
 mbed compile -m $BOARD -t $TOOL
 cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-WifiXNucleo.bin
 
@@ -108,3 +100,12 @@ cp configs/wifi_rtw_v4.json mbed_app.json
 patch_wifi
 mbed compile -m $BOARD -t $TOOL
 cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-Wifi.bin
+
+echo DISCO_L475VG_IOT01A with Wi-Fi
+BOARD=DISCO_L475VG_IOT01A
+cp configs/wifi_ism43362.json mbed_app.json
+patch_wifi
+mbed compile -m $BOARD -t $TOOL
+cp ./BUILD/$BOARD/$TOOL/mbed-os-example-client.bin $BOARD-$TOOL-ism43362.bin
+
+

--- a/easy-connect.lib
+++ b/easy-connect.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/easy-connect/#06594ba91bc141f08fe4024d0e9471605827cbd0
+https://github.com/ARMmbed/easy-connect/#48d7e16f0e965766787b7383fbf0cd1d00b1efb5


### PR DESCRIPTION
Update easy-connect to truly enable DISCO_L475VG_IOT01A + ISM43362
combination (this also brings in one Cellular fix at the same time).

Fix the issues in `build_all.sh`, it still had some references to
`.mbedignore` -files, which are irrelevant now.
