### PR TITLE
EMAC override to default i/f ethernet

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,8 @@ As ARM Compiler 5.06 update *3* has multiple compiler bugs (issue 2 above), we r
 
 ### UBLOX_EVK_ODIN_W2
 
-Pre-built WiFi binaries are broken for UBLOX_EVK_ODIN_W2 between Mbed OS 5.7.5 to 5.7.x, issue [6003](ARMmbed/mbed-os#6003) (fixed to Mbed OS 5.8.0).
+* Pre-built WiFi binaries are broken for UBLOX_EVK_ODIN_W2 between Mbed OS 5.7.5 to 5.7.x, issue [6003](ARMmbed/mbed-os#6003) (fixed to Mbed OS 5.8.0).
+* UBLOX_EVK_ODIN_W2 hard-faults when compiled with Mbed OS 5.9 & IAR, issue [7173](https://github.com/ARMmbed/mbed-os/issues/7137).
 
 ### REALTEK_RTL8195AM
 

--- a/configs/eth_odin_v4.json
+++ b/configs/eth_odin_v4.json
@@ -15,8 +15,8 @@
             "lwip.ipv6-enabled": false,
             "mbed-trace.enable": 0
         },
-            "UBLOX_EVK_ODIN_W2": {
-            "target.device_has_remove": ["EMAC"]
+        "UBLOX_EVK_ODIN_W2": {
+             "target.network-default-interface-type": "ETHERNET"
         }
     }
 }

--- a/configs/eth_odin_v6.json
+++ b/configs/eth_odin_v6.json
@@ -15,8 +15,8 @@
             "lwip.ipv6-enabled": true,
             "mbed-trace.enable": 0
         },
-            "UBLOX_EVK_ODIN_W2": {
-            "target.device_has_remove": ["EMAC"]
+        "UBLOX_EVK_ODIN_W2": {
+             "target.network-default-interface-type": "ETHERNET"
         }
     }
 }

--- a/configs/eth_v4.json
+++ b/configs/eth_v4.json
@@ -19,8 +19,8 @@
             "lwip.ipv6-enabled": false,
             "mbed-trace.enable": 0
         },
-            "UBLOX_EVK_ODIN_W2": {
-            "target.device_has_remove": ["EMAC"]
+        "UBLOX_EVK_ODIN_W2": {
+             "target.network-default-interface-type": "ETHERNET"
         }
     }
 }

--- a/configs/eth_v6.json
+++ b/configs/eth_v6.json
@@ -19,8 +19,8 @@
             "lwip.ipv6-enabled": true,
             "mbed-trace.enable": 0
         },
-            "UBLOX_EVK_ODIN_W2": {
-            "target.device_has_remove": ["EMAC"]
+        "UBLOX_EVK_ODIN_W2": {
+             "target.network-default-interface-type": "ETHERNET"
         }
     }
 }

--- a/configs/wifi_odin_v4.json
+++ b/configs/wifi_odin_v4.json
@@ -17,7 +17,7 @@
         	"value": "BUTTON1"
         }
     },
-    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\""],
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_mbed_client_config.h\"", "MBED_CONF_RSA_REQUIRED"],
     "target_overrides": {
         "*": {
             "target.features_add": ["LWIP", "COMMON_PAL"],

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -45,7 +45,7 @@
             "wifi-rx": "PA_12"
         },
         "UBLOX_EVK_ODIN_W2": {
-            "target.device_has_remove": ["EMAC"]
+            "target.network-default-interface-type": "ETHERNET"
         },
         "UBLOX_C030_U201": {
             "lwip.ppp-enabled": true,

--- a/mbedtls_mbed_client_config.h
+++ b/mbedtls_mbed_client_config.h
@@ -77,9 +77,17 @@
 #define MBEDTLS_ECDSA_C
 #define MBEDTLS_X509_CRT_PARSE_C
 
-// Remove RSA, save 20KB at total
-#undef MBEDTLS_RSA_C
-#undef MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+// Remove RSA, save 20KB at total.
+// However, with Mbed OS 5.9 onwards - UBLOX_EVK_ODIN_W2 must have RSA!
+// A more abstract macro define added for that which you can trigger via
+// macros -part in the mbed_app.json.
+#if !defined(MBED_CONF_RSA_REQUIRED)
+    #undef MBEDTLS_RSA_C
+    #undef MBEDTLS_PK_RSA_ALT_SUPPORT
+    #undef MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+    #undef MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+    #undef MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
+#endif // !MBED_CONF_RSA_REQUIRED
 
 // Remove error messages, save 10KB of ROM
 #undef MBEDTLS_ERROR_C


### PR DESCRIPTION
UBLOX_EVK_ODIN_W2 over ethernet will not work as Mbed OS 5.9 changed
the way EMAC works. We have to use a different way to do the switch
to ethernet with that board with Mbed OS 5.9 and onwards.
